### PR TITLE
W1: GitHub REST adapter + gh CLI fallback (#9)

### DIFF
--- a/src/agent_estimate/adapters/github_adapter.py
+++ b/src/agent_estimate/adapters/github_adapter.py
@@ -1,0 +1,61 @@
+"""Shared types and interface for GitHub issue adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence
+
+
+class GitHubAdapterError(RuntimeError):
+    """Raised when issue retrieval from GitHub fails."""
+
+
+@dataclass(frozen=True)
+class GitHubIssue:
+    """Normalized issue payload used by estimators."""
+
+    number: int
+    title: str
+    body: str
+    task_description: str
+
+
+def build_task_description(title: str, body: str | None) -> str:
+    """Build one task description from issue title and body text."""
+    trimmed_title = title.strip()
+    trimmed_body = (body or "").strip()
+    if not trimmed_body:
+        return trimmed_title
+    return f"{trimmed_title}\n\n{trimmed_body}"
+
+
+class GitHubIssueAdapter(Protocol):
+    """Swappable issue adapter interface."""
+
+    def fetch_issues_by_numbers(self, repo: str, issue_numbers: Sequence[int]) -> list[GitHubIssue]:
+        """Fetch specific issues by number."""
+
+    def fetch_issues_by_label(
+        self,
+        repo: str,
+        label: str,
+        *,
+        state: str = "open",
+    ) -> list[GitHubIssue]:
+        """Fetch issues by label with repository-specific filtering."""
+
+    def fetch_task_descriptions_by_numbers(
+        self,
+        repo: str,
+        issue_numbers: Sequence[int],
+    ) -> list[str]:
+        """Fetch and transform issue data into estimation task descriptions."""
+
+    def fetch_task_descriptions_by_label(
+        self,
+        repo: str,
+        label: str,
+        *,
+        state: str = "open",
+    ) -> list[str]:
+        """Fetch labeled issues and transform them into task descriptions."""

--- a/src/agent_estimate/adapters/github_ghcli.py
+++ b/src/agent_estimate/adapters/github_ghcli.py
@@ -1,1 +1,109 @@
-"""GitHub CLI adapter (stub)."""
+"""GitHub CLI adapter fallback for issue ingestion."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Callable, Sequence
+
+from agent_estimate.adapters.github_adapter import (
+    GitHubAdapterError,
+    GitHubIssue,
+    build_task_description,
+)
+
+
+class GitHubGhCliAdapter:
+    """Fetch GitHub issues through gh CLI commands."""
+
+    def __init__(self, runner: Callable[[list[str]], str] | None = None) -> None:
+        self._runner = runner or _run_gh
+
+    def fetch_issues_by_numbers(self, repo: str, issue_numbers: Sequence[int]) -> list[GitHubIssue]:
+        """Fetch specific issues by number."""
+        issues: list[GitHubIssue] = []
+        for issue_number in issue_numbers:
+            output = self._runner(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(issue_number),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,title,body",
+                ],
+            )
+            payload = json.loads(output)
+            issues.append(_parse_issue(payload))
+        return issues
+
+    def fetch_issues_by_label(
+        self,
+        repo: str,
+        label: str,
+        *,
+        state: str = "open",
+    ) -> list[GitHubIssue]:
+        """Fetch issues by label with a high limit for CLI pagination fallback."""
+        output = self._runner(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--label",
+                label,
+                "--state",
+                state,
+                "--limit",
+                "1000",
+                "--json",
+                "number,title,body",
+            ],
+        )
+        payload = json.loads(output)
+        if not isinstance(payload, list):
+            raise GitHubAdapterError(f"Unexpected gh issue list output: {payload!r}")
+        return [_parse_issue(raw_issue) for raw_issue in payload]
+
+    def fetch_task_descriptions_by_numbers(
+        self,
+        repo: str,
+        issue_numbers: Sequence[int],
+    ) -> list[str]:
+        """Fetch issues by number and return task descriptions."""
+        return [issue.task_description for issue in self.fetch_issues_by_numbers(repo, issue_numbers)]
+
+    def fetch_task_descriptions_by_label(
+        self,
+        repo: str,
+        label: str,
+        *,
+        state: str = "open",
+    ) -> list[str]:
+        """Fetch labeled issues and return task descriptions."""
+        return [issue.task_description for issue in self.fetch_issues_by_label(repo, label, state=state)]
+
+
+def _run_gh(args: list[str]) -> str:
+    result = subprocess.run(args, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise GitHubAdapterError(
+            f"gh command failed ({' '.join(args)}): {result.stderr.strip() or result.stdout.strip()}",
+        )
+    return result.stdout
+
+
+def _parse_issue(payload: dict[str, object]) -> GitHubIssue:
+    number = int(payload["number"])
+    title = str(payload.get("title", ""))
+    body = str(payload.get("body") or "")
+    return GitHubIssue(
+        number=number,
+        title=title,
+        body=body,
+        task_description=build_task_description(title=title, body=body),
+    )

--- a/src/agent_estimate/adapters/github_rest.py
+++ b/src/agent_estimate/adapters/github_rest.py
@@ -1,1 +1,206 @@
-"""GitHub REST API adapter (stub)."""
+"""GitHub REST API adapter for issue ingestion."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from typing import Callable, Mapping, Sequence
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from agent_estimate.adapters.github_adapter import (
+    GitHubAdapterError,
+    GitHubIssue,
+    build_task_description,
+)
+
+BASE_URL = "https://api.github.com"
+
+
+class GitHubRestAdapter:
+    """Fetch GitHub issues through the REST API."""
+
+    def __init__(
+        self,
+        token: str | None = None,
+        *,
+        max_retries: int = 3,
+        initial_backoff_seconds: float = 1.0,
+        timeout_seconds: float = 15.0,
+        request_fn: Callable[[str, Mapping[str, str]], tuple[int, dict[str, str], str]] | None = None,
+        sleep_fn: Callable[[float], None] = time.sleep,
+        now_fn: Callable[[], float] = time.time,
+        token_provider: Callable[[], str] | None = None,
+    ) -> None:
+        self._token = token or (token_provider or _resolve_github_token)()
+        self._max_retries = max_retries
+        self._initial_backoff_seconds = initial_backoff_seconds
+        self._timeout_seconds = timeout_seconds
+        self._request_fn = request_fn or self._default_request
+        self._sleep_fn = sleep_fn
+        self._now_fn = now_fn
+
+    def fetch_issues_by_numbers(self, repo: str, issue_numbers: Sequence[int]) -> list[GitHubIssue]:
+        """Fetch specific issues by number."""
+        issues: list[GitHubIssue] = []
+        for issue_number in issue_numbers:
+            payload, _ = self._request_json(
+                f"{BASE_URL}/repos/{repo}/issues/{issue_number}",
+            )
+            if not isinstance(payload, dict):
+                raise GitHubAdapterError(f"Unexpected payload for issue #{issue_number}: {payload!r}")
+            if "pull_request" in payload:
+                continue
+            issues.append(_parse_issue(payload))
+        return issues
+
+    def fetch_issues_by_label(
+        self,
+        repo: str,
+        label: str,
+        *,
+        state: str = "open",
+    ) -> list[GitHubIssue]:
+        """Fetch issues by label, handling paginated API responses."""
+        issues: list[GitHubIssue] = []
+        page = 1
+        while True:
+            query = urlencode({"state": state, "labels": label, "per_page": 100, "page": page})
+            payload, _ = self._request_json(f"{BASE_URL}/repos/{repo}/issues?{query}")
+            if not isinstance(payload, list):
+                raise GitHubAdapterError(
+                    f"Unexpected payload when listing issues by label '{label}': {payload!r}",
+                )
+            if not payload:
+                break
+            for raw_issue in payload:
+                if isinstance(raw_issue, dict) and "pull_request" not in raw_issue:
+                    issues.append(_parse_issue(raw_issue))
+            if len(payload) < 100:
+                break
+            page += 1
+        return issues
+
+    def fetch_task_descriptions_by_numbers(
+        self,
+        repo: str,
+        issue_numbers: Sequence[int],
+    ) -> list[str]:
+        """Fetch issues by number and return task descriptions."""
+        return [issue.task_description for issue in self.fetch_issues_by_numbers(repo, issue_numbers)]
+
+    def fetch_task_descriptions_by_label(
+        self,
+        repo: str,
+        label: str,
+        *,
+        state: str = "open",
+    ) -> list[str]:
+        """Fetch labeled issues and return task descriptions."""
+        return [issue.task_description for issue in self.fetch_issues_by_label(repo, label, state=state)]
+
+    def _request_json(self, url: str) -> tuple[object, dict[str, str]]:
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self._token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "agent-estimate",
+        }
+
+        for attempt in range(self._max_retries + 1):
+            status, response_headers, body = self._request_fn(url, headers)
+            normalized_headers = {key.lower(): value for key, value in response_headers.items()}
+
+            if status < 400:
+                return json.loads(body), normalized_headers
+
+            if _is_rate_limited(status, normalized_headers) and attempt < self._max_retries:
+                self._sleep_fn(
+                    _compute_retry_delay(
+                        headers=normalized_headers,
+                        attempt=attempt,
+                        initial_backoff_seconds=self._initial_backoff_seconds,
+                        now_seconds=self._now_fn(),
+                    ),
+                )
+                continue
+
+            raise GitHubAdapterError(
+                f"GitHub API request failed with status {status} for {url}: {body[:200]}",
+            )
+
+        raise GitHubAdapterError(f"GitHub API request failed after retries for {url}")
+
+    def _default_request(self, url: str, headers: Mapping[str, str]) -> tuple[int, dict[str, str], str]:
+        request = Request(url=url, headers=dict(headers), method="GET")
+        try:
+            with urlopen(request, timeout=self._timeout_seconds) as response:
+                return response.status, dict(response.headers.items()), response.read().decode("utf-8")
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            return exc.code, dict(exc.headers.items()) if exc.headers else {}, body
+
+
+def _resolve_github_token() -> str:
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        return token
+
+    result = subprocess.run(
+        ["gh", "auth", "token"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        message = result.stderr.strip() or "gh auth token returned no token"
+        raise GitHubAdapterError(
+            "GitHub authentication required. Set GITHUB_TOKEN or login with gh CLI. "
+            f"Details: {message}",
+        )
+    return result.stdout.strip()
+
+
+def _parse_issue(raw_issue: Mapping[str, object]) -> GitHubIssue:
+    number = int(raw_issue["number"])
+    title = str(raw_issue.get("title", ""))
+    body = str(raw_issue.get("body") or "")
+    return GitHubIssue(
+        number=number,
+        title=title,
+        body=body,
+        task_description=build_task_description(title=title, body=body),
+    )
+
+
+def _is_rate_limited(status: int, headers: Mapping[str, str]) -> bool:
+    if status == 429:
+        return True
+    return status == 403 and headers.get("x-ratelimit-remaining") == "0"
+
+
+def _compute_retry_delay(
+    *,
+    headers: Mapping[str, str],
+    attempt: int,
+    initial_backoff_seconds: float,
+    now_seconds: float,
+) -> float:
+    retry_after = headers.get("retry-after")
+    if retry_after:
+        try:
+            return max(float(retry_after), 1.0)
+        except ValueError:
+            pass
+
+    reset_epoch = headers.get("x-ratelimit-reset")
+    if reset_epoch:
+        try:
+            return max(float(reset_epoch) - now_seconds, 1.0)
+        except ValueError:
+            pass
+
+    return max(initial_backoff_seconds * (2**attempt), 1.0)

--- a/tests/unit/test_github_adapters.py
+++ b/tests/unit/test_github_adapters.py
@@ -1,0 +1,115 @@
+"""Unit tests for GitHub issue adapters."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from collections.abc import Mapping
+
+from agent_estimate.adapters.github_ghcli import GitHubGhCliAdapter
+from agent_estimate.adapters.github_rest import GitHubRestAdapter
+
+
+def test_rest_adapter_fetches_issues_by_number_and_builds_task_descriptions() -> None:
+    responses = {
+        "https://api.github.com/repos/acme/repo/issues/1": (
+            200,
+            {},
+            json.dumps({"number": 1, "title": "Fix parser", "body": "Handle YAML edge cases"}),
+        ),
+        "https://api.github.com/repos/acme/repo/issues/2": (
+            200,
+            {},
+            json.dumps({"number": 2, "title": "Write tests", "body": ""}),
+        ),
+    }
+
+    def request_fn(url: str, headers: Mapping[str, str]) -> tuple[int, dict[str, str], str]:
+        assert headers["Authorization"] == "Bearer test-token"
+        return responses[url]
+
+    adapter = GitHubRestAdapter(token_provider=lambda: "test-token", request_fn=request_fn)
+    issues = adapter.fetch_issues_by_numbers("acme/repo", [1, 2])
+
+    assert [issue.number for issue in issues] == [1, 2]
+    assert issues[0].task_description == "Fix parser\n\nHandle YAML edge cases"
+    assert issues[1].task_description == "Write tests"
+
+
+def test_rest_adapter_handles_pagination_for_label_queries() -> None:
+    first_page = [{"number": i, "title": f"Issue {i}", "body": "Body"} for i in range(1, 101)]
+    second_page = [
+        {"number": 101, "title": "Issue 101", "body": "Body"},
+        {"number": 102, "title": "Issue 102", "body": "Body"},
+    ]
+
+    responses = {
+        "https://api.github.com/repos/acme/repo/issues?state=open&labels=bug&per_page=100&page=1": (
+            200,
+            {},
+            json.dumps(first_page),
+        ),
+        "https://api.github.com/repos/acme/repo/issues?state=open&labels=bug&per_page=100&page=2": (
+            200,
+            {},
+            json.dumps(second_page),
+        ),
+    }
+
+    def request_fn(url: str, _: Mapping[str, str]) -> tuple[int, dict[str, str], str]:
+        return responses[url]
+
+    adapter = GitHubRestAdapter(token_provider=lambda: "test-token", request_fn=request_fn)
+    issues = adapter.fetch_issues_by_label("acme/repo", "bug")
+
+    assert len(issues) == 102
+    assert issues[0].number == 1
+    assert issues[-1].number == 102
+
+
+def test_rest_adapter_retries_when_rate_limited() -> None:
+    calls = defaultdict(int)
+    sleep_calls: list[float] = []
+
+    def request_fn(url: str, _: Mapping[str, str]) -> tuple[int, dict[str, str], str]:
+        calls[url] += 1
+        if calls[url] == 1:
+            return (
+                403,
+                {"x-ratelimit-remaining": "0", "x-ratelimit-reset": "102"},
+                '{"message":"rate limited"}',
+            )
+        return 200, {}, json.dumps({"number": 7, "title": "Retry me", "body": "Worked"})
+
+    adapter = GitHubRestAdapter(
+        token_provider=lambda: "test-token",
+        request_fn=request_fn,
+        sleep_fn=lambda seconds: sleep_calls.append(seconds),
+        now_fn=lambda: 100.0,
+    )
+
+    issues = adapter.fetch_issues_by_numbers("acme/repo", [7])
+
+    assert issues[0].number == 7
+    assert sleep_calls == [2.0]
+
+
+def test_gh_cli_adapter_fetches_issues_by_number_and_label() -> None:
+    def runner(args: list[str]) -> str:
+        if args[:3] == ["gh", "issue", "view"]:
+            return json.dumps({"number": 9, "title": "CLI title", "body": "CLI body"})
+        if args[:3] == ["gh", "issue", "list"]:
+            return json.dumps(
+                [
+                    {"number": 10, "title": "Label title", "body": "Body"},
+                    {"number": 11, "title": "Second title", "body": ""},
+                ],
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    adapter = GitHubGhCliAdapter(runner=runner)
+    by_number = adapter.fetch_task_descriptions_by_numbers("acme/repo", [9])
+    by_label = adapter.fetch_task_descriptions_by_label("acme/repo", "estimate")
+
+    assert by_number == ["CLI title\n\nCLI body"]
+    assert by_label == ["Label title\n\nBody", "Second title"]


### PR DESCRIPTION
## Summary
- add shared swappable GitHub issue adapter interface (`GitHubIssueAdapter`) and normalized issue model
- implement REST adapter with repo issue fetch by number/label, title+body task parsing, pagination, token auth fallback, and rate-limit retry/backoff
- implement `gh` CLI fallback adapter with compatible methods for issue number/label lookups
- add mocked unit tests covering REST parsing, pagination, rate-limit retry, and gh CLI adapter behavior

## Validation
- `ruff check .`
- `pytest -q`

Closes #9
