### PR TITLE
feat: JSON output renderer (#7)

### DIFF
--- a/src/agent_estimate/cli/commands/estimate.py
+++ b/src/agent_estimate/cli/commands/estimate.py
@@ -14,7 +14,7 @@ from agent_estimate.adapters.github_ghcli import GitHubGhCliAdapter
 from agent_estimate.cli.commands._pipeline import run_estimate_pipeline
 from agent_estimate.cli.commands.github import parse_issue_selection
 from agent_estimate.core import ReviewMode
-from agent_estimate.render import render_markdown_report
+from agent_estimate.render import render_json_report, render_markdown_report
 
 logger = logging.getLogger("agent_estimate")
 
@@ -110,7 +110,7 @@ def run(
     if format == "markdown":
         typer.echo(render_markdown_report(report))
     elif format == "json":
-        _error("JSON output not yet implemented.", 1)
+        typer.echo(render_json_report(report), nl=False)
     else:
         _error(f"Unknown format: {format!r}. Use markdown or json.", 2)
 

--- a/src/agent_estimate/render/__init__.py
+++ b/src/agent_estimate/render/__init__.py
@@ -1,5 +1,6 @@
 """Output rendering modules."""
 
+from agent_estimate.render.json_report import render_json_report
 from agent_estimate.render.markdown_report import render_markdown_report
 from agent_estimate.render.report_models import (
     EstimationReport,
@@ -15,5 +16,6 @@ __all__ = [
     "ReportTask",
     "ReportTimeline",
     "ReportWave",
+    "render_json_report",
     "render_markdown_report",
 ]

--- a/src/agent_estimate/render/json_report.py
+++ b/src/agent_estimate/render/json_report.py
@@ -1,1 +1,88 @@
-"""JSON report renderer (stub)."""
+"""JSON report renderer."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent_estimate.render.report_models import EstimationReport, ReportWave
+
+
+def render_json_report(report: EstimationReport) -> str:
+    """Render an estimation report as canonical JSON."""
+    payload = _build_payload(report)
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _build_payload(report: EstimationReport) -> dict[str, Any]:
+    critical_tasks = set(report.critical_path)
+    warnings = [
+        {
+            "task": task.name,
+            "warning": task.metr_warning,
+        }
+        for task in report.tasks
+        if task.metr_warning is not None
+    ]
+
+    return {
+        "title": report.title,
+        "tasks": [
+            {
+                "name": task.name,
+                "tier": task.tier,
+                "agent": task.agent,
+                "base_pert": {
+                    "optimistic_minutes": task.base_pert_optimistic_minutes,
+                    "most_likely_minutes": task.base_pert_most_likely_minutes,
+                    "pessimistic_minutes": task.base_pert_pessimistic_minutes,
+                    "expected_minutes": task.base_pert_expected_minutes,
+                },
+                "modifiers": {
+                    "spec_clarity": task.modifier_spec_clarity,
+                    "warm_context": task.modifier_warm_context,
+                    "agent_fit": task.modifier_agent_fit,
+                    "combined": task.modifier_combined,
+                },
+                "effective_duration_minutes": task.effective_duration_minutes,
+                "human_equivalent_minutes": task.human_equivalent_minutes,
+                "review_overhead_minutes": task.review_overhead_minutes,
+                "metr_warning": task.metr_warning,
+                "is_critical_path": task.name in critical_tasks,
+            }
+            for task in report.tasks
+        ],
+        "waves": [_wave_payload(wave) for wave in sorted(report.waves, key=lambda wave: wave.number)],
+        "timeline": {
+            "best_case_minutes": report.timeline.best_case_minutes,
+            "expected_case_minutes": report.timeline.expected_case_minutes,
+            "worst_case_minutes": report.timeline.worst_case_minutes,
+            "human_equivalent_minutes": report.timeline.human_equivalent_minutes,
+            "compression_ratio": report.timeline.compression_ratio,
+            "review_overhead_minutes": report.review_overhead_minutes,
+        },
+        "agent_load": [
+            {
+                "agent": load.agent,
+                "task_count": load.task_count,
+                "total_work_minutes": load.total_work_minutes,
+                "estimated_cost": load.estimated_cost,
+            }
+            for load in sorted(report.agent_load, key=lambda load: load.agent)
+        ],
+        "critical_path": list(report.critical_path),
+        "metr_warnings": warnings,
+    }
+
+
+def _wave_payload(wave: ReportWave) -> dict[str, Any]:
+    assignments = {
+        agent: sorted(tasks)
+        for agent, tasks in sorted(wave.agent_assignments.items(), key=lambda item: item[0])
+    }
+    return {
+        "number": wave.number,
+        "tasks": sorted(wave.tasks),
+        "duration_minutes": wave.duration_minutes,
+        "agent_assignments": assignments,
+    }

--- a/tests/fixtures/json_report_golden.json
+++ b/tests/fixtures/json_report_golden.json
@@ -1,0 +1,99 @@
+{
+  "agent_load": [
+    {
+      "agent": "Claude",
+      "estimated_cost": 9.3,
+      "task_count": 1,
+      "total_work_minutes": 30.5
+    },
+    {
+      "agent": "Codex",
+      "estimated_cost": 18.4,
+      "task_count": 1,
+      "total_work_minutes": 72.5
+    }
+  ],
+  "critical_path": [
+    "Implement auth",
+    "Add tests"
+  ],
+  "metr_warnings": [
+    {
+      "task": "Implement auth",
+      "warning": "Estimate exceeds threshold"
+    }
+  ],
+  "tasks": [
+    {
+      "agent": "Codex",
+      "base_pert": {
+        "expected_minutes": 52.5,
+        "most_likely_minutes": 50.0,
+        "optimistic_minutes": 25.0,
+        "pessimistic_minutes": 90.0
+      },
+      "effective_duration_minutes": 57.8,
+      "human_equivalent_minutes": 160.0,
+      "is_critical_path": true,
+      "metr_warning": "Estimate exceeds threshold",
+      "modifiers": {
+        "agent_fit": 1.0,
+        "combined": 1.1,
+        "spec_clarity": 1.1,
+        "warm_context": 1.0
+      },
+      "name": "Implement auth",
+      "review_overhead_minutes": 17.5,
+      "tier": "M"
+    },
+    {
+      "agent": "Claude",
+      "base_pert": {
+        "expected_minutes": 24.0,
+        "most_likely_minutes": 23.0,
+        "optimistic_minutes": 12.0,
+        "pessimistic_minutes": 40.0
+      },
+      "effective_duration_minutes": 24.0,
+      "human_equivalent_minutes": 75.0,
+      "is_critical_path": true,
+      "metr_warning": null,
+      "modifiers": {
+        "agent_fit": 1.0,
+        "combined": 1.0,
+        "spec_clarity": 1.0,
+        "warm_context": 1.0
+      },
+      "name": "Add tests",
+      "review_overhead_minutes": 7.5,
+      "tier": "S"
+    }
+  ],
+  "timeline": {
+    "best_case_minutes": 70.0,
+    "compression_ratio": 2.7777777777777777,
+    "expected_case_minutes": 90.0,
+    "human_equivalent_minutes": 250.0,
+    "review_overhead_minutes": 25.0,
+    "worst_case_minutes": 130.0
+  },
+  "title": "W3 Estimate",
+  "waves": [
+    {
+      "agent_assignments": {
+        "Claude": [
+          "Add tests"
+        ],
+        "Codex": [
+          "Implement auth"
+        ]
+      },
+      "duration_minutes": 85.0,
+      "number": 1,
+      "tasks": [
+        "Add tests",
+        "Implement auth"
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_json_report.py
+++ b/tests/unit/test_json_report.py
@@ -1,0 +1,128 @@
+"""Tests for JSON report rendering and CLI JSON output."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from agent_estimate.cli.app import app
+from agent_estimate.render.json_report import render_json_report
+from agent_estimate.render.report_models import (
+    EstimationReport,
+    ReportAgentLoad,
+    ReportTask,
+    ReportTimeline,
+    ReportWave,
+)
+
+_RUNNER = CliRunner()
+
+
+def _build_report() -> EstimationReport:
+    return EstimationReport(
+        title="W3 Estimate",
+        tasks=(
+            ReportTask(
+                name="Implement auth",
+                tier="M",
+                agent="Codex",
+                base_pert_optimistic_minutes=25.0,
+                base_pert_most_likely_minutes=50.0,
+                base_pert_pessimistic_minutes=90.0,
+                modifier_spec_clarity=1.1,
+                modifier_warm_context=1.0,
+                modifier_agent_fit=1.0,
+                modifier_combined=1.1,
+                effective_duration_minutes=57.8,
+                human_equivalent_minutes=160.0,
+                review_overhead_minutes=17.5,
+                metr_warning="Estimate exceeds threshold",
+            ),
+            ReportTask(
+                name="Add tests",
+                tier="S",
+                agent="Claude",
+                base_pert_optimistic_minutes=12.0,
+                base_pert_most_likely_minutes=23.0,
+                base_pert_pessimistic_minutes=40.0,
+                modifier_spec_clarity=1.0,
+                modifier_warm_context=1.0,
+                modifier_agent_fit=1.0,
+                modifier_combined=1.0,
+                effective_duration_minutes=24.0,
+                human_equivalent_minutes=75.0,
+                review_overhead_minutes=7.5,
+                metr_warning=None,
+            ),
+        ),
+        waves=(
+            ReportWave(
+                number=1,
+                tasks=("Implement auth", "Add tests"),
+                duration_minutes=85.0,
+                agent_assignments={
+                    "Codex": ("Implement auth",),
+                    "Claude": ("Add tests",),
+                },
+            ),
+        ),
+        timeline=ReportTimeline(
+            best_case_minutes=70.0,
+            expected_case_minutes=90.0,
+            worst_case_minutes=130.0,
+            human_equivalent_minutes=250.0,
+        ),
+        agent_load=(
+            ReportAgentLoad(
+                agent="Codex",
+                task_count=1,
+                total_work_minutes=72.5,
+                estimated_cost=18.4,
+            ),
+            ReportAgentLoad(
+                agent="Claude",
+                task_count=1,
+                total_work_minutes=30.5,
+                estimated_cost=9.3,
+            ),
+        ),
+        critical_path=("Implement auth", "Add tests"),
+    )
+
+
+def test_render_json_report_matches_golden_fixture() -> None:
+    report = _build_report()
+
+    rendered = render_json_report(report)
+    golden_path = Path(__file__).resolve().parents[1] / "fixtures" / "json_report_golden.json"
+    golden = golden_path.read_text(encoding="utf-8")
+
+    assert rendered == golden
+
+
+def test_render_json_report_is_canonical_and_round_trips() -> None:
+    rendered = render_json_report(_build_report())
+
+    payload = json.loads(rendered)
+    normalized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+    assert rendered == normalized
+    assert json.loads(normalized) == payload
+    assert {"tasks", "waves", "timeline", "agent_load", "critical_path", "metr_warnings"} <= set(
+        payload
+    )
+
+
+def test_estimate_command_json_format_outputs_json() -> None:
+    result = _RUNNER.invoke(
+        app,
+        ["estimate", "Implement OAuth login flow", "--format", "json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert "tasks" in payload
+    assert "waves" in payload
+    assert "timeline" in payload


### PR DESCRIPTION
## Summary
- implement canonical JSON renderer for `EstimationReport`
- wire `agent-estimate estimate --format json`
- add golden fixture + renderer/CLI tests

## Validation
- `ruff check .`
- `pytest -q`

Closes #7
