### PR TITLE
Add /estimate Claude Code skill wrapper

### DIFF
--- a/src/agent_estimate/skill/SKILL.md
+++ b/src/agent_estimate/skill/SKILL.md
@@ -14,7 +14,7 @@ Run PERT three-point estimation with METR reliability thresholds and wave planni
 /estimate --file <path>
 /estimate --issues <numbers> --repo <owner/name>
 /estimate --config <path> <task>
-/estimate --format json <task>
+/estimate --format json <task>       # NOT YET IMPLEMENTED — returns exit code 1
 /estimate --review-mode none <task>
 /estimate --title "My Report" <task>
 /validate-estimate <observation.yaml>
@@ -37,6 +37,12 @@ Determine which subcommand to run based on context:
 
 ### 2. Build the CLI command
 
+#### Global flags (all subcommands)
+
+| Flag | Short | Description |
+|---|---|---|
+| `--verbose` | `-v` | Enable debug logging — useful when a command exits non-zero |
+
 #### For `/estimate`
 
 Parse these optional flags from user input and pass them through verbatim:
@@ -45,7 +51,7 @@ Parse these optional flags from user input and pass them through verbatim:
 |---|---|---|
 | `--file <path>` | `-f` | Path to task file (one task per line) |
 | `--config <path>` | `-c` | Path to config YAML with agent definitions |
-| `--format <fmt>` | | Output format: `markdown` (default) or `json` |
+| `--format <fmt>` | | Output format: `markdown` (default). `json` is not yet implemented. |
 | `--review-mode <mode>` | | Review overhead: `none`, `self`, `2x-lgtm` (default) |
 | `--issues <nums>` | `-i` | Comma-separated GitHub issue numbers |
 | `--repo <owner/name>` | `-r` | GitHub repo (required with `--issues`) |
@@ -60,7 +66,7 @@ The argument after `/validate-estimate` is the observation YAML file path. Optio
 
 #### For `/calibrate`
 
-Optionally pass `--db <path>` if provided.
+Optionally pass `--db <path>` if provided. Default: `~/.agent-estimate/calibration.db`.
 
 ### 3. Run the command
 

--- a/src/agent_estimate/skill/claude_wrapper.py
+++ b/src/agent_estimate/skill/claude_wrapper.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+
+def _build_base_cmd(subcommand: str) -> list[str]:
+    """Build the base CLI command, preferring the installed binary."""
+    binary = shutil.which("agent-estimate")
+    if binary:
+        return [binary, subcommand]
+    return [sys.executable, "-m", "agent_estimate.cli.app", subcommand]
 
 
 def run_estimate(
@@ -28,7 +37,7 @@ def run_estimate(
     if sources > 1:
         raise ValueError("Provide only one input source: task, file, or issues.")
 
-    cmd: list[str] = [sys.executable, "-m", "agent_estimate.cli.app", "estimate"]
+    cmd: list[str] = _build_base_cmd("estimate")
 
     if task is not None:
         cmd.append(task)
@@ -55,13 +64,8 @@ def run_validate(
     db: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Invoke ``agent-estimate validate`` programmatically."""
-    cmd: list[str] = [
-        sys.executable,
-        "-m",
-        "agent_estimate.cli.app",
-        "validate",
-        str(observation_file),
-    ]
+    cmd: list[str] = _build_base_cmd("validate")
+    cmd.append(str(observation_file))
     if db is not None:
         cmd += ["--db", str(db)]
     return subprocess.run(cmd, capture_output=True, text=True)
@@ -69,7 +73,7 @@ def run_validate(
 
 def run_calibrate(db: Path | None = None) -> subprocess.CompletedProcess[str]:
     """Invoke ``agent-estimate calibrate`` programmatically."""
-    cmd: list[str] = [sys.executable, "-m", "agent_estimate.cli.app", "calibrate"]
+    cmd: list[str] = _build_base_cmd("calibrate")
     if db is not None:
         cmd += ["--db", str(db)]
     return subprocess.run(cmd, capture_output=True, text=True)


### PR DESCRIPTION
## Summary

- Add `src/agent_estimate/skill/SKILL.md` — a Claude Code skill definition covering `/estimate`, `/validate-estimate`, and `/calibrate` invocation patterns with full flag pass-through
- Replace stub `claude_wrapper.py` with a thin programmatic adapter exposing `run_estimate()`, `run_validate()`, and `run_calibrate()` for direct Python use
- Supports all CLI flags: `--file`, `--config`, `--format`, `--review-mode`, `--issues`, `--repo`, `--title`, `--db`

## Test plan

- [ ] Verify `ruff check .` passes (done — all checks passed)
- [ ] Install in dev mode and run `/estimate "Add a login button"` via Claude Code skill invocation
- [ ] Confirm `--file`, `--issues`, and `--config` pass-through works
- [ ] Confirm `/validate-estimate` and `/calibrate` route to correct subcommands
- [ ] Confirm `claude_wrapper.py` functions are importable and accept correct args

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)