### PR TITLE
Add comprehensive unit tests for core modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,72 @@
+"""Shared fixtures for agent_estimate test suite."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_estimate.core.models import (
+    AgentProfile,
+    EstimationConfig,
+    ModifierSet,
+    ProjectSettings,
+    SizeTier,
+    SizingResult,
+    TaskType,
+)
+from agent_estimate.core.modifiers import build_modifier_set
+from agent_estimate.core.sizing import TIER_BASELINES
+
+
+@pytest.fixture
+def sample_agent_profile() -> AgentProfile:
+    """A valid AgentProfile for use in tests."""
+    return AgentProfile(
+        name="Claude",
+        capabilities=["code", "planning"],
+        parallelism=2,
+        cost_per_turn=0.12,
+        model_tier="frontier",
+    )
+
+
+@pytest.fixture
+def sample_project_settings() -> ProjectSettings:
+    """A valid ProjectSettings for use in tests."""
+    return ProjectSettings(
+        friction_multiplier=1.1,
+        inter_wave_overhead=0.25,
+        review_overhead=0.15,
+        metr_fallback_threshold=40.0,
+    )
+
+
+@pytest.fixture
+def sample_estimation_config(
+    sample_agent_profile: AgentProfile,
+    sample_project_settings: ProjectSettings,
+) -> EstimationConfig:
+    """A valid EstimationConfig with one agent."""
+    return EstimationConfig(
+        agents=[sample_agent_profile],
+        settings=sample_project_settings,
+    )
+
+
+@pytest.fixture
+def neutral_modifier_set() -> ModifierSet:
+    """All modifiers at 1.0 — neutral, combined=1.0."""
+    return build_modifier_set()
+
+
+@pytest.fixture
+def sample_sizing_result() -> SizingResult:
+    """A SizingResult for a medium FEATURE task."""
+    o, m, p = TIER_BASELINES[SizeTier.M]
+    return SizingResult(
+        tier=SizeTier.M,
+        baseline_optimistic=o,
+        baseline_most_likely=m,
+        baseline_pessimistic=p,
+        task_type=TaskType.FEATURE,
+        signals=("test-fixture",),
+    )

--- a/tests/unit/test_config_loader_gaps.py
+++ b/tests/unit/test_config_loader_gaps.py
@@ -1,0 +1,61 @@
+"""Additional config_loader tests filling coverage gaps."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_estimate.adapters.config_loader import load_config
+
+
+def _write(tmp_path: Path, filename: str, content: str) -> Path:
+    path = tmp_path / filename
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Non-existent path
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigNonExistentPath:
+    def test_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="Config file not found"):
+            load_config(tmp_path / "does_not_exist.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Empty YAML
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigEmptyYaml:
+    def test_empty_file_raises_validation_error(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "empty.yaml", "")
+        # Empty YAML → raw_data is None → treated as {} → fails EstimationConfig validation
+        with pytest.raises(ValueError):
+            load_config(path)
+
+    def test_yaml_with_only_comments_raises(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "comments.yaml", "# just a comment\n")
+        with pytest.raises(ValueError):
+            load_config(path)
+
+
+# ---------------------------------------------------------------------------
+# YAML root is a list, not a dict
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigYamlRootList:
+    def test_root_list_raises_value_error(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "list.yaml", "- item1\n- item2\n")
+        with pytest.raises(ValueError, match="root must be a YAML mapping"):
+            load_config(path)
+
+    def test_root_string_raises_value_error(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, "string.yaml", "just a string\n")
+        with pytest.raises(ValueError, match="root must be a YAML mapping"):
+            load_config(path)

--- a/tests/unit/test_github_helpers.py
+++ b/tests/unit/test_github_helpers.py
@@ -1,0 +1,45 @@
+"""Tests for cli/commands/github.py helper functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_estimate.cli.commands.github import parse_issue_selection
+
+
+class TestParseIssueSelection:
+    def test_valid_comma_separated(self) -> None:
+        assert parse_issue_selection("1,2,3") == [1, 2, 3]
+
+    def test_single_issue(self) -> None:
+        assert parse_issue_selection("42") == [42]
+
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert parse_issue_selection("") == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        assert parse_issue_selection("   ") == []
+
+    def test_values_with_surrounding_spaces(self) -> None:
+        assert parse_issue_selection(" 1 , 2 , 3 ") == [1, 2, 3]
+
+    def test_non_integer_token_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_issue_selection("1,two,3")
+
+    def test_floating_point_token_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_issue_selection("1.5,2")
+
+    def test_empty_tokens_between_commas_ignored(self) -> None:
+        # "1,,3" → strip(",") leaves empty middle, which is skipped by `if part.strip()`
+        result = parse_issue_selection("1,,3")
+        assert result == [1, 3]
+
+    def test_trailing_comma_ignored(self) -> None:
+        result = parse_issue_selection("1,2,")
+        assert result == [1, 2]
+
+    def test_large_issue_numbers(self) -> None:
+        result = parse_issue_selection("1000,9999")
+        assert result == [1000, 9999]

--- a/tests/unit/test_human_comparison.py
+++ b/tests/unit/test_human_comparison.py
@@ -1,0 +1,106 @@
+"""Tests for core/human_comparison.py — all task types."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from agent_estimate.core.human_comparison import compute_human_equivalent, get_human_multiplier
+from agent_estimate.core.models import TaskType
+
+
+# Expected geometric-mean multipliers from _HUMAN_MULTIPLIERS
+_EXPECTED_MULTIPLIERS: dict[TaskType, tuple[float, float]] = {
+    TaskType.BOILERPLATE: (3.0, 5.0),
+    TaskType.BUG_FIX: (1.5, 3.0),
+    TaskType.FEATURE: (2.0, 4.0),
+    TaskType.REFACTOR: (2.0, 3.5),
+    TaskType.TEST: (2.5, 4.5),
+    TaskType.DOCS: (3.0, 6.0),
+    TaskType.UNKNOWN: (2.0, 4.0),
+}
+
+
+class TestGetHumanMultiplier:
+    @pytest.mark.parametrize("task_type,expected_range", list(_EXPECTED_MULTIPLIERS.items()))
+    def test_multiplier_is_geometric_mean(
+        self, task_type: TaskType, expected_range: tuple[float, float]
+    ) -> None:
+        lo, hi = expected_range
+        expected = math.sqrt(lo * hi)
+        assert get_human_multiplier(task_type) == pytest.approx(expected)
+
+    def test_all_task_types_covered(self) -> None:
+        for task_type in TaskType:
+            mult = get_human_multiplier(task_type)
+            assert mult > 1.0, f"{task_type} multiplier should be > 1.0"
+
+    def test_boilerplate_multiplier_value(self) -> None:
+        assert get_human_multiplier(TaskType.BOILERPLATE) == pytest.approx(math.sqrt(15.0))
+
+    def test_bug_fix_multiplier_value(self) -> None:
+        assert get_human_multiplier(TaskType.BUG_FIX) == pytest.approx(math.sqrt(4.5))
+
+    def test_feature_multiplier_value(self) -> None:
+        assert get_human_multiplier(TaskType.FEATURE) == pytest.approx(math.sqrt(8.0))
+
+    def test_refactor_multiplier_value(self) -> None:
+        assert get_human_multiplier(TaskType.REFACTOR) == pytest.approx(math.sqrt(7.0))
+
+    def test_test_task_multiplier_value(self) -> None:
+        assert get_human_multiplier(TaskType.TEST) == pytest.approx(math.sqrt(11.25))
+
+    def test_docs_multiplier_value(self) -> None:
+        assert get_human_multiplier(TaskType.DOCS) == pytest.approx(math.sqrt(18.0))
+
+    def test_unknown_multiplier_equals_feature(self) -> None:
+        assert get_human_multiplier(TaskType.UNKNOWN) == pytest.approx(
+            get_human_multiplier(TaskType.FEATURE)
+        )
+
+
+class TestComputeHumanEquivalent:
+    def test_feature_type(self) -> None:
+        agent_min = 30.0
+        result = compute_human_equivalent(agent_min, TaskType.FEATURE)
+        assert result == pytest.approx(agent_min * math.sqrt(8.0))
+
+    def test_bug_fix_type(self) -> None:
+        agent_min = 60.0
+        result = compute_human_equivalent(agent_min, TaskType.BUG_FIX)
+        assert result == pytest.approx(60.0 * math.sqrt(4.5))
+
+    def test_boilerplate_type(self) -> None:
+        agent_min = 10.0
+        result = compute_human_equivalent(agent_min, TaskType.BOILERPLATE)
+        assert result == pytest.approx(10.0 * math.sqrt(15.0))
+
+    def test_refactor_type(self) -> None:
+        agent_min = 45.0
+        result = compute_human_equivalent(agent_min, TaskType.REFACTOR)
+        assert result == pytest.approx(45.0 * math.sqrt(7.0))
+
+    def test_test_type(self) -> None:
+        agent_min = 20.0
+        result = compute_human_equivalent(agent_min, TaskType.TEST)
+        assert result == pytest.approx(20.0 * math.sqrt(11.25))
+
+    def test_docs_type(self) -> None:
+        agent_min = 15.0
+        result = compute_human_equivalent(agent_min, TaskType.DOCS)
+        assert result == pytest.approx(15.0 * math.sqrt(18.0))
+
+    def test_unknown_type(self) -> None:
+        agent_min = 25.0
+        result = compute_human_equivalent(agent_min, TaskType.UNKNOWN)
+        assert result == pytest.approx(25.0 * math.sqrt(8.0))
+
+    def test_zero_agent_minutes(self) -> None:
+        result = compute_human_equivalent(0.0, TaskType.FEATURE)
+        assert result == pytest.approx(0.0)
+
+    def test_human_equivalent_always_greater_than_agent(self) -> None:
+        for task_type in TaskType:
+            result = compute_human_equivalent(100.0, task_type)
+            assert result > 100.0

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,206 @@
+"""Tests for Pydantic config models and dataclass constraints in core/models.py."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agent_estimate.core.models import (
+    AgentProfile,
+    EstimationConfig,
+    ProjectSettings,
+    SizeTier,
+    SizingResult,
+    TaskType,
+)
+from agent_estimate.core.modifiers import build_modifier_set
+from agent_estimate.core.sizing import TIER_BASELINES
+
+
+# ---------------------------------------------------------------------------
+# AgentProfile validation
+# ---------------------------------------------------------------------------
+
+
+class TestAgentProfileValidation:
+    def _valid(self, **overrides: object) -> dict:
+        base: dict = {
+            "name": "Claude",
+            "capabilities": ["code"],
+            "parallelism": 1,
+            "cost_per_turn": 0.0,
+            "model_tier": "frontier",
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_profile_parses(self) -> None:
+        profile = AgentProfile(**self._valid())
+        assert profile.name == "Claude"
+
+    def test_empty_name_raises(self) -> None:
+        with pytest.raises(ValidationError, match="name"):
+            AgentProfile(**self._valid(name=""))
+
+    def test_whitespace_only_name_raises(self) -> None:
+        with pytest.raises(ValidationError, match="name"):
+            AgentProfile(**self._valid(name="   "))
+
+    def test_zero_parallelism_raises(self) -> None:
+        with pytest.raises(ValidationError, match="parallelism"):
+            AgentProfile(**self._valid(parallelism=0))
+
+    def test_negative_parallelism_raises(self) -> None:
+        with pytest.raises(ValidationError, match="parallelism"):
+            AgentProfile(**self._valid(parallelism=-1))
+
+    def test_negative_cost_per_turn_raises(self) -> None:
+        with pytest.raises(ValidationError, match="cost_per_turn"):
+            AgentProfile(**self._valid(cost_per_turn=-0.01))
+
+    def test_zero_cost_per_turn_accepted(self) -> None:
+        profile = AgentProfile(**self._valid(cost_per_turn=0.0))
+        assert profile.cost_per_turn == 0.0
+
+    def test_empty_capabilities_list_raises(self) -> None:
+        with pytest.raises(ValidationError, match="capabilities"):
+            AgentProfile(**self._valid(capabilities=[]))
+
+    def test_extra_field_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentProfile(**self._valid(unknown_field="oops"))
+
+
+# ---------------------------------------------------------------------------
+# ProjectSettings validation
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSettingsValidation:
+    def _valid(self, **overrides: object) -> dict:
+        base: dict = {
+            "friction_multiplier": 1.0,
+            "inter_wave_overhead": 0.0,
+            "review_overhead": 0.0,
+            "metr_fallback_threshold": 40.0,
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_settings_parse(self) -> None:
+        s = ProjectSettings(**self._valid())
+        assert s.friction_multiplier == pytest.approx(1.0)
+
+    def test_zero_friction_multiplier_raises(self) -> None:
+        with pytest.raises(ValidationError, match="friction_multiplier"):
+            ProjectSettings(**self._valid(friction_multiplier=0.0))
+
+    def test_negative_friction_multiplier_raises(self) -> None:
+        with pytest.raises(ValidationError, match="friction_multiplier"):
+            ProjectSettings(**self._valid(friction_multiplier=-1.0))
+
+    def test_negative_review_overhead_raises(self) -> None:
+        with pytest.raises(ValidationError, match="review_overhead"):
+            ProjectSettings(**self._valid(review_overhead=-0.1))
+
+    def test_negative_inter_wave_overhead_raises(self) -> None:
+        with pytest.raises(ValidationError, match="inter_wave_overhead"):
+            ProjectSettings(**self._valid(inter_wave_overhead=-0.5))
+
+    def test_zero_metr_fallback_threshold_raises(self) -> None:
+        with pytest.raises(ValidationError, match="metr_fallback_threshold"):
+            ProjectSettings(**self._valid(metr_fallback_threshold=0.0))
+
+
+# ---------------------------------------------------------------------------
+# EstimationConfig
+# ---------------------------------------------------------------------------
+
+
+class TestEstimationConfig:
+    def _agent(self) -> AgentProfile:
+        return AgentProfile(
+            name="Claude",
+            capabilities=["code"],
+            parallelism=1,
+            cost_per_turn=0.0,
+            model_tier="frontier",
+        )
+
+    def _settings(self) -> ProjectSettings:
+        return ProjectSettings(
+            friction_multiplier=1.0,
+            inter_wave_overhead=0.0,
+            review_overhead=0.0,
+            metr_fallback_threshold=40.0,
+        )
+
+    def test_valid_config(self) -> None:
+        cfg = EstimationConfig(agents=[self._agent()], settings=self._settings())
+        assert len(cfg.agents) == 1
+
+    def test_empty_agents_list_raises(self) -> None:
+        with pytest.raises(ValidationError, match="agents"):
+            EstimationConfig(agents=[], settings=self._settings())
+
+    def test_multiple_agents_accepted(self) -> None:
+        cfg = EstimationConfig(
+            agents=[self._agent(), self._agent()],
+            settings=self._settings(),
+        )
+        assert len(cfg.agents) == 2
+
+
+# ---------------------------------------------------------------------------
+# SizeTier enum ordering
+# ---------------------------------------------------------------------------
+
+
+class TestSizeTierOrdering:
+    def test_all_five_tiers_exist(self) -> None:
+        tiers = list(SizeTier)
+        assert len(tiers) == 5
+
+    def test_tier_values(self) -> None:
+        assert SizeTier.XS.value == "XS"
+        assert SizeTier.S.value == "S"
+        assert SizeTier.M.value == "M"
+        assert SizeTier.L.value == "L"
+        assert SizeTier.XL.value == "XL"
+
+    def test_baselines_present_for_all_tiers(self) -> None:
+        for tier in SizeTier:
+            assert tier in TIER_BASELINES
+            o, m, p = TIER_BASELINES[tier]
+            assert o < m < p
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclasses — immutability
+# ---------------------------------------------------------------------------
+
+
+class TestFrozenDataclasses:
+    def test_modifier_set_is_frozen(self) -> None:
+        mods = build_modifier_set()
+        with pytest.raises(AttributeError):
+            mods.combined = 99.0  # type: ignore[misc]
+
+    def test_pert_result_is_frozen(self) -> None:
+        from agent_estimate.core.pert import compute_pert
+
+        result = compute_pert(10.0, 20.0, 30.0)
+        with pytest.raises(AttributeError):
+            result.expected = 0.0  # type: ignore[misc]
+
+    def test_sizing_result_is_frozen(self) -> None:
+        o, m, p = TIER_BASELINES[SizeTier.S]
+        sizing = SizingResult(
+            tier=SizeTier.S,
+            baseline_optimistic=o,
+            baseline_most_likely=m,
+            baseline_pessimistic=p,
+            task_type=TaskType.FEATURE,
+        )
+        with pytest.raises(AttributeError):
+            sizing.tier = SizeTier.XL  # type: ignore[misc]

--- a/tests/unit/test_modifiers.py
+++ b/tests/unit/test_modifiers.py
@@ -1,0 +1,152 @@
+"""Dedicated tests for core/modifiers.py covering boundary values and composition."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_estimate.core.models import ReviewMode
+from agent_estimate.core.modifiers import (
+    apply_modifiers,
+    build_modifier_set,
+    compute_review_overhead,
+)
+
+
+# ---------------------------------------------------------------------------
+# Boundary values for spec_clarity
+# ---------------------------------------------------------------------------
+
+
+class TestSpecClarityBoundaries:
+    def test_spec_clarity_lower_boundary_accepted(self) -> None:
+        mods = build_modifier_set(spec_clarity=0.8)
+        assert mods.spec_clarity == pytest.approx(0.8)
+
+    def test_spec_clarity_upper_boundary_accepted(self) -> None:
+        mods = build_modifier_set(spec_clarity=1.3)
+        assert mods.spec_clarity == pytest.approx(1.3)
+
+    def test_spec_clarity_below_lower_raises(self) -> None:
+        with pytest.raises(ValueError, match="spec_clarity"):
+            build_modifier_set(spec_clarity=0.79)
+
+    def test_spec_clarity_above_upper_raises(self) -> None:
+        with pytest.raises(ValueError, match="spec_clarity"):
+            build_modifier_set(spec_clarity=1.31)
+
+
+# ---------------------------------------------------------------------------
+# Boundary values for warm_context
+# ---------------------------------------------------------------------------
+
+
+class TestWarmContextBoundaries:
+    def test_warm_context_lower_boundary_accepted(self) -> None:
+        mods = build_modifier_set(warm_context=0.85)
+        assert mods.warm_context == pytest.approx(0.85)
+
+    def test_warm_context_upper_boundary_accepted(self) -> None:
+        mods = build_modifier_set(warm_context=1.15)
+        assert mods.warm_context == pytest.approx(1.15)
+
+    def test_warm_context_below_lower_raises(self) -> None:
+        with pytest.raises(ValueError, match="warm_context"):
+            build_modifier_set(warm_context=0.84)
+
+    def test_warm_context_above_upper_raises(self) -> None:
+        with pytest.raises(ValueError, match="warm_context"):
+            build_modifier_set(warm_context=1.16)
+
+
+# ---------------------------------------------------------------------------
+# Boundary values for agent_fit
+# ---------------------------------------------------------------------------
+
+
+class TestAgentFitBoundaries:
+    def test_agent_fit_lower_boundary_accepted(self) -> None:
+        mods = build_modifier_set(agent_fit=0.9)
+        assert mods.agent_fit == pytest.approx(0.9)
+
+    def test_agent_fit_upper_boundary_accepted(self) -> None:
+        mods = build_modifier_set(agent_fit=1.2)
+        assert mods.agent_fit == pytest.approx(1.2)
+
+    def test_agent_fit_below_lower_raises(self) -> None:
+        with pytest.raises(ValueError, match="agent_fit"):
+            build_modifier_set(agent_fit=0.89)
+
+    def test_agent_fit_above_upper_raises(self) -> None:
+        with pytest.raises(ValueError, match="agent_fit"):
+            build_modifier_set(agent_fit=1.21)
+
+
+# ---------------------------------------------------------------------------
+# Combined modifier product correctness
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedModifierProduct:
+    def test_combined_is_exact_product_of_three(self) -> None:
+        sc, wc, af = 1.2, 1.05, 1.1
+        mods = build_modifier_set(spec_clarity=sc, warm_context=wc, agent_fit=af)
+        assert mods.combined == pytest.approx(sc * wc * af)
+
+    def test_all_lower_boundaries_product(self) -> None:
+        mods = build_modifier_set(spec_clarity=0.8, warm_context=0.85, agent_fit=0.9)
+        assert mods.combined == pytest.approx(0.8 * 0.85 * 0.9)
+
+    def test_all_upper_boundaries_product(self) -> None:
+        mods = build_modifier_set(spec_clarity=1.3, warm_context=1.15, agent_fit=1.2)
+        assert mods.combined == pytest.approx(1.3 * 1.15 * 1.2)
+
+    def test_combined_stored_correctly_in_frozen_dataclass(self) -> None:
+        mods = build_modifier_set(spec_clarity=1.1, warm_context=1.0, agent_fit=1.0)
+        assert mods.combined == pytest.approx(1.1)
+        with pytest.raises(AttributeError):
+            mods.combined = 99.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# apply_modifiers
+# ---------------------------------------------------------------------------
+
+
+class TestApplyModifiers:
+    def test_neutral_modifier_leaves_base_unchanged(self) -> None:
+        mods = build_modifier_set()
+        assert apply_modifiers(100.0, mods) == pytest.approx(100.0)
+
+    def test_scale_up(self) -> None:
+        mods = build_modifier_set(spec_clarity=1.3)
+        assert apply_modifiers(100.0, mods) == pytest.approx(130.0)
+
+    def test_scale_down(self) -> None:
+        mods = build_modifier_set(spec_clarity=0.8, warm_context=0.85, agent_fit=0.9)
+        expected = 200.0 * 0.8 * 0.85 * 0.9
+        assert apply_modifiers(200.0, mods) == pytest.approx(expected)
+
+    def test_zero_base_gives_zero(self) -> None:
+        mods = build_modifier_set(spec_clarity=1.2)
+        assert apply_modifiers(0.0, mods) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# compute_review_overhead — all ReviewMode values
+# ---------------------------------------------------------------------------
+
+
+class TestComputeReviewOverhead:
+    def test_none_mode_is_zero(self) -> None:
+        assert compute_review_overhead(ReviewMode.NONE) == pytest.approx(0.0)
+
+    def test_self_mode_is_seven_and_half(self) -> None:
+        assert compute_review_overhead(ReviewMode.SELF) == pytest.approx(7.5)
+
+    def test_two_lgtm_mode_is_seventeen_and_half(self) -> None:
+        assert compute_review_overhead(ReviewMode.TWO_LGTM) == pytest.approx(17.5)
+
+    def test_all_review_modes_covered(self) -> None:
+        for mode in ReviewMode:
+            overhead = compute_review_overhead(mode)
+            assert overhead >= 0.0

--- a/tests/unit/test_pert_gaps.py
+++ b/tests/unit/test_pert_gaps.py
@@ -1,0 +1,140 @@
+"""Additional PERT tests filling coverage gaps not in test_pert_engine.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_estimate.core.models import SizeTier, SizingResult, TaskType
+from agent_estimate.core.modifiers import build_modifier_set
+from agent_estimate.core.pert import (
+    check_metr_threshold,
+    estimate_task,
+    load_metr_thresholds,
+)
+from agent_estimate.core.sizing import TIER_BASELINES
+
+
+def _sizing(tier: SizeTier = SizeTier.S) -> SizingResult:
+    o, m, p = TIER_BASELINES[tier]
+    return SizingResult(
+        tier=tier,
+        baseline_optimistic=o,
+        baseline_most_likely=m,
+        baseline_pessimistic=p,
+        task_type=TaskType.FEATURE,
+        signals=(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# load_metr_thresholds — malformed YAML
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMetrThresholdsMalformed:
+    def test_malformed_yaml_raises_runtime_error(self, tmp_path: Path) -> None:
+        malformed_yaml = "models:\n  opus: not_a_dict_with_p80\n"
+
+        def fake_read_text(encoding: str) -> str:
+            return malformed_yaml
+
+        # Patch the resource path to return a tmp file we control
+        bad_yaml = tmp_path / "bad.yaml"
+        bad_yaml.write_text("models:\n  opus:\n    no_p80_key: 10\n", encoding="utf-8")
+
+        with patch(
+            "agent_estimate.core.pert.files"
+        ) as mock_files:
+            mock_resource = mock_files.return_value.joinpath.return_value
+
+            class FakePath:
+                def read_text(self, encoding: str) -> str:
+                    return "models:\n  opus:\n    no_p80_key: 10\n"
+
+                def __enter__(self) -> "FakePath":
+                    return self
+
+                def __exit__(self, *_: object) -> None:
+                    pass
+
+            mock_resource.__enter__ = lambda s: FakePath()
+            mock_resource.__exit__ = lambda s, *_: None
+
+            from contextlib import contextmanager
+
+            @contextmanager  # type: ignore[misc]
+            def fake_as_file(resource: object):  # type: ignore[misc]
+                yield FakePath()
+
+            with patch("agent_estimate.core.pert.as_file", fake_as_file):
+                with pytest.raises(RuntimeError, match="Malformed"):
+                    load_metr_thresholds()
+
+    def test_malformed_metr_yaml_via_file(self, tmp_path: Path) -> None:
+        # Write a YAML that parses OK but has wrong structure (no p80_minutes key)
+        bad_yaml = tmp_path / "metr_thresholds.yaml"
+        bad_yaml.write_text(
+            "models:\n  opus:\n    something_else: 10\n", encoding="utf-8"
+        )
+
+        from contextlib import contextmanager
+
+        @contextmanager  # type: ignore[misc]
+        def fake_as_file(resource: object):  # type: ignore[misc]
+            yield bad_yaml
+
+        with patch("agent_estimate.core.pert.as_file", fake_as_file):
+            with pytest.raises(RuntimeError, match="Malformed"):
+                load_metr_thresholds()
+
+
+# ---------------------------------------------------------------------------
+# estimate_task with explicit fallback_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateTaskFallbackThreshold:
+    def test_explicit_fallback_threshold_used_when_model_unknown(self) -> None:
+        sizing = _sizing(SizeTier.M)
+        mods = build_modifier_set()
+        thresholds: dict[str, float] = {}  # empty — no known models
+
+        # M tier expected ~50 min; fallback=10.0 → should warn
+        result = estimate_task(
+            sizing, mods, model_key="unknown", thresholds=thresholds, fallback_threshold=10.0
+        )
+        assert result.metr_warning is not None
+        assert result.metr_warning.threshold_minutes == pytest.approx(10.0)
+
+    def test_explicit_fallback_threshold_no_warn_when_below(self) -> None:
+        sizing = _sizing(SizeTier.XS)
+        mods = build_modifier_set()
+        thresholds: dict[str, float] = {}
+
+        # XS tier expected ~10 min; fallback=999.0 → no warn
+        result = estimate_task(
+            sizing, mods, model_key="new_model", thresholds=thresholds, fallback_threshold=999.0
+        )
+        assert result.metr_warning is None
+
+
+# ---------------------------------------------------------------------------
+# check_metr_threshold — thresholds=None triggers load
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMetrThresholdAutoLoad:
+    def test_none_thresholds_triggers_file_load(self) -> None:
+        # Should not raise and should return a valid result using the real YAML
+        result = check_metr_threshold("opus", 50.0, thresholds=None)
+        # 50.0 is well within opus threshold of 90.0
+        assert result is None
+
+    def test_none_thresholds_warn_for_large_estimate(self) -> None:
+        # A huge estimate should trigger warning via auto-load
+        result = check_metr_threshold("opus", 99999.0, thresholds=None)
+        assert result is not None
+        assert result.model_key == "opus"

--- a/tests/unit/test_sizing.py
+++ b/tests/unit/test_sizing.py
@@ -1,0 +1,134 @@
+"""Tests for core/sizing.py — task type detection, edge cases, tier clamping."""
+
+from __future__ import annotations
+
+from agent_estimate.core.models import SizeTier, TaskType
+from agent_estimate.core.sizing import _bump_tier, classify_task
+
+
+# ---------------------------------------------------------------------------
+# Task type detection — all types
+# ---------------------------------------------------------------------------
+
+
+class TestTaskTypeDetection:
+    def test_boilerplate_detection(self) -> None:
+        result = classify_task("Generate boilerplate for the new module")
+        assert result.task_type == TaskType.BOILERPLATE
+
+    def test_bug_fix_detection(self) -> None:
+        result = classify_task("Fix a regression in the login flow")
+        assert result.task_type == TaskType.BUG_FIX
+
+    def test_feature_detection(self) -> None:
+        result = classify_task("Implement a new caching layer")
+        assert result.task_type == TaskType.FEATURE
+
+    def test_refactor_detection(self) -> None:
+        result = classify_task("Refactor the payment module to reduce duplication")
+        assert result.task_type == TaskType.REFACTOR
+
+    def test_test_detection(self) -> None:
+        result = classify_task("Write test coverage for the auth module")
+        assert result.task_type == TaskType.TEST
+
+    def test_docs_detection(self) -> None:
+        result = classify_task("Update the README with setup instructions")
+        assert result.task_type == TaskType.DOCS
+
+    def test_unknown_type_when_no_keyword(self) -> None:
+        result = classify_task("Do the thing with the stuff")
+        assert result.task_type == TaskType.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Whitespace-only description
+# ---------------------------------------------------------------------------
+
+
+class TestWhitespaceDescription:
+    def test_whitespace_only_defaults_to_m(self) -> None:
+        result = classify_task("   ")
+        assert result.tier == SizeTier.M
+        assert result.task_type == TaskType.UNKNOWN
+
+    def test_whitespace_only_signal_is_no_description_default(self) -> None:
+        result = classify_task("\t\n  ")
+        assert "no-description-default-M" in result.signals
+
+
+# ---------------------------------------------------------------------------
+# Multiple complexity signals — bump by 2
+# ---------------------------------------------------------------------------
+
+
+class TestComplexitySignalBumps:
+    def test_two_complexity_signals_bump_tier_by_one(self) -> None:
+        # "simple" → S, plus database + security = 2 complexity signals → S+1 = M
+        result = classify_task("Simple database migration with security tokens")
+        assert result.tier == SizeTier.M
+
+    def test_four_complexity_signals_bump_tier_by_two(self) -> None:
+        # "simple" → S, plus database + security + api + test = 4 signals → S+2 = L
+        result = classify_task(
+            "Simple database migration with security auth api endpoint and test coverage"
+        )
+        assert result.tier == SizeTier.L
+
+    def test_one_complexity_signal_no_bump(self) -> None:
+        # "simple" → S, plus database = 1 signal → still S
+        result = classify_task("Simple database change")
+        assert result.tier == SizeTier.S
+
+    def test_complexity_signals_recorded(self) -> None:
+        result = classify_task("Simple database migration with security tokens")
+        assert "database-change" in result.signals
+        assert "security-concern" in result.signals
+
+
+# ---------------------------------------------------------------------------
+# Tier vote median with conflicting signals
+# ---------------------------------------------------------------------------
+
+
+class TestTierVoteMedian:
+    def test_conflicting_signals_picks_median(self) -> None:
+        # "simple" → S vote, "large" → L vote → median of [S, L] = L (index 1 of 2)
+        result = classify_task("Simple but large refactoring task")
+        # Sorted: [S, L], median index = 2//2 = 1 → L
+        # But "refactoring" triggers structural-change complexity signal → may bump further
+        # The structural-change is 1 complexity signal → no bump yet
+        assert result.tier in (SizeTier.L, SizeTier.XL)
+
+    def test_all_same_tier_votes_return_that_tier(self) -> None:
+        result = classify_task("trivial rename one-liner typo")
+        assert result.tier == SizeTier.XS
+
+
+# ---------------------------------------------------------------------------
+# _bump_tier clamping at XL
+# ---------------------------------------------------------------------------
+
+
+class TestBumpTierClamping:
+    def test_bump_from_xl_stays_at_xl(self) -> None:
+        assert _bump_tier(SizeTier.XL, 1) == SizeTier.XL
+
+    def test_bump_large_steps_from_xl_stays_at_xl(self) -> None:
+        assert _bump_tier(SizeTier.XL, 5) == SizeTier.XL
+
+    def test_bump_l_by_one_gives_xl(self) -> None:
+        assert _bump_tier(SizeTier.L, 1) == SizeTier.XL
+
+    def test_bump_xs_by_two_gives_m(self) -> None:
+        assert _bump_tier(SizeTier.XS, 2) == SizeTier.M
+
+    def test_bump_xs_by_zero_gives_xs(self) -> None:
+        assert _bump_tier(SizeTier.XS, 0) == SizeTier.XS
+
+    def test_bump_m_by_ten_clamps_at_xl(self) -> None:
+        assert _bump_tier(SizeTier.M, 10) == SizeTier.XL
+
+    def test_epic_keyword_already_at_xl_no_bump_needed(self) -> None:
+        result = classify_task("Massive rewrite of the entire auth system")
+        assert result.tier == SizeTier.XL

--- a/tests/unit/test_sqlite_gaps.py
+++ b/tests/unit/test_sqlite_gaps.py
@@ -1,0 +1,202 @@
+"""Additional SQLite store tests filling coverage gaps."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from agent_estimate.adapters.sqlite_store import (
+    ObservationInput,
+    SQLiteCalibrationStore,
+    _percentile,
+)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Generator[SQLiteCalibrationStore, None, None]:
+    calibration_store = SQLiteCalibrationStore(tmp_path / "calibration.db")
+    yield calibration_store
+    calibration_store.close()
+
+
+def _observation(**overrides: object) -> ObservationInput:
+    base = dict(
+        task_type="feature",
+        estimated_secs=120.0,
+        actual_work_secs=140.0,
+        actual_total_secs=150.0,
+        error_ratio=0.2,
+        file_count=3,
+        line_count=220,
+        test_count=4,
+        project_hash="proj-123",
+        spec_clarity_modifier=0.8,
+        warm_context_modifier=0.6,
+        execution_mode="sync",
+        review_mode="async",
+        review_overhead_secs=30.0,
+        verdict="pass",
+        modifiers_should_have_been={"spec_clarity": 0.75},
+        observed_at="2026-02-16T12:00:00+00:00",
+    )
+    base.update(overrides)
+    return ObservationInput(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _validate_observation — empty strings
+# ---------------------------------------------------------------------------
+
+
+class TestValidateObservationEmptyStrings:
+    def test_empty_task_type_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="task_type"):
+            store.insert_observation(_observation(task_type=""))
+
+    def test_whitespace_task_type_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="task_type"):
+            store.insert_observation(_observation(task_type="   "))
+
+    def test_empty_project_hash_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="project_hash"):
+            store.insert_observation(_observation(project_hash=""))
+
+    def test_empty_execution_mode_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="execution_mode"):
+            store.insert_observation(_observation(execution_mode=""))
+
+    def test_empty_review_mode_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="review_mode"):
+            store.insert_observation(_observation(review_mode=""))
+
+    def test_empty_verdict_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="verdict"):
+            store.insert_observation(_observation(verdict=""))
+
+
+# ---------------------------------------------------------------------------
+# _validate_observation — negative numeric fields
+# ---------------------------------------------------------------------------
+
+
+class TestValidateObservationNegativeValues:
+    def test_negative_actual_work_secs_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="actual_work_secs"):
+            store.insert_observation(_observation(actual_work_secs=-1.0))
+
+    def test_negative_actual_total_secs_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="actual_total_secs"):
+            store.insert_observation(_observation(actual_total_secs=-0.5))
+
+    def test_negative_error_ratio_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="error_ratio"):
+            store.insert_observation(_observation(error_ratio=-0.1))
+
+    def test_negative_review_overhead_secs_raises(self, store: SQLiteCalibrationStore) -> None:
+        with pytest.raises(ValueError, match="review_overhead_secs"):
+            store.insert_observation(_observation(review_overhead_secs=-5.0))
+
+    def test_zero_values_accepted(self, store: SQLiteCalibrationStore) -> None:
+        obs_id = store.insert_observation(
+            _observation(
+                actual_work_secs=0.0,
+                actual_total_secs=0.0,
+                error_ratio=0.0,
+                review_overhead_secs=0.0,
+            )
+        )
+        assert obs_id > 0
+
+
+# ---------------------------------------------------------------------------
+# _percentile edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPercentileEdgeCases:
+    def test_empty_list_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="percentile requires at least one value"):
+            _percentile([], 50.0)
+
+    def test_single_value_returns_that_value(self) -> None:
+        assert _percentile([42.0], 50.0) == pytest.approx(42.0)
+
+    def test_single_value_at_p0(self) -> None:
+        assert _percentile([7.0], 0.0) == pytest.approx(7.0)
+
+    def test_single_value_at_p100(self) -> None:
+        assert _percentile([7.0], 100.0) == pytest.approx(7.0)
+
+    def test_two_values_median(self) -> None:
+        result = _percentile([10.0, 20.0], 50.0)
+        assert result == pytest.approx(15.0)
+
+
+# ---------------------------------------------------------------------------
+# Multiple task types in one calibrate cycle
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleTaskTypesCalibrate:
+    def test_multiple_task_types_produce_separate_summary_rows(
+        self, store: SQLiteCalibrationStore
+    ) -> None:
+        for _ in range(5):
+            store.insert_observation(_observation(task_type="feature", error_ratio=0.2))
+        for _ in range(5):
+            store.insert_observation(_observation(task_type="bugfix", error_ratio=0.3))
+
+        store.calibrate()
+        summaries = store.query_calibration_summary()
+
+        task_types = {row["task_type"] for row in summaries}
+        assert "feature" in task_types
+        assert "bugfix" in task_types
+        assert len(summaries) == 2
+
+    def test_each_task_type_has_correct_count(
+        self, store: SQLiteCalibrationStore
+    ) -> None:
+        for i in range(3):
+            store.insert_observation(_observation(task_type="alpha", error_ratio=0.1 * (i + 1)))
+        for i in range(7):
+            store.insert_observation(_observation(task_type="beta", error_ratio=0.05 * (i + 1)))
+
+        store.calibrate()
+        summaries = {row["task_type"]: row for row in store.query_calibration_summary()}
+
+        assert summaries["alpha"]["sample_count"] == 3
+        assert summaries["beta"]["sample_count"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Custom k_anonymity_floor
+# ---------------------------------------------------------------------------
+
+
+class TestCustomKAnonymityFloor:
+    def test_custom_floor_of_3_allows_smaller_cohorts(self, tmp_path: Path) -> None:
+        store = SQLiteCalibrationStore(tmp_path / "k3.db", k_anonymity_floor=3)
+        try:
+            for i in range(3):
+                store.insert_observation(_observation(task_type="small", error_ratio=0.1 * (i + 1)))
+            store.calibrate()
+            exported = store.export_calibration_summary(allow_export=True)
+            assert len(exported) == 1
+            assert exported[0]["task_type"] == "small"
+        finally:
+            store.close()
+
+    def test_default_floor_of_5_excludes_small_cohorts(self, tmp_path: Path) -> None:
+        store = SQLiteCalibrationStore(tmp_path / "k5.db")  # default k=5
+        try:
+            for i in range(4):  # 4 < 5
+                store.insert_observation(_observation(task_type="tiny", error_ratio=0.1 * (i + 1)))
+            store.calibrate()
+            exported = store.export_calibration_summary(allow_export=True)
+            # 4 records < floor=5, so excluded
+            assert len(exported) == 0
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary

- Adds 135 new unit tests across 9 new files, growing the suite from 81 → 216 tests
- Creates `tests/conftest.py` with shared fixtures for AgentProfile, EstimationConfig, ModifierSet, SizingResult
- Fills all specified coverage gaps: modifiers, models, human_comparison, sizing, github helpers, pert edge cases, sqlite validation, config_loader edge cases

## New files

| File | Coverage area |
|------|--------------|
| `tests/conftest.py` | Shared pytest fixtures |
| `tests/unit/test_modifiers.py` | Boundary values, combined product, apply_modifiers, all ReviewMode values |
| `tests/unit/test_models.py` | Pydantic validation for AgentProfile/ProjectSettings/EstimationConfig, frozen dataclasses, SizeTier ordering |
| `tests/unit/test_human_comparison.py` | All TaskType multipliers (parametrized), compute_human_equivalent for all types |
| `tests/unit/test_sizing.py` | All task type detection, whitespace-only descriptions, complexity signal bumping, _bump_tier XL clamping |
| `tests/unit/test_github_helpers.py` | parse_issue_selection: valid, empty, non-integer, trailing commas |
| `tests/unit/test_pert_gaps.py` | Malformed METR YAML → RuntimeError, explicit fallback_threshold, None thresholds auto-load |
| `tests/unit/test_sqlite_gaps.py` | Empty string validation, negative numerics, _percentile edge cases, multi-type calibrate cycles, custom k_anonymity_floor |
| `tests/unit/test_config_loader_gaps.py` | Non-existent path, empty YAML, root-list YAML |

## Test plan

- [x] `python3 -m pytest tests/unit/ -x -q` → 216 passed
- [x] `ruff check .` → All checks passed

Closes #11