### PR TITLE
W6: Packaging + TestPyPI dry-run flow (#14)

### DIFF
--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build distributions
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build==1.4.0 twine==6.2.0
           python -m build
           python -m twine check dist/*
       - name: Publish to TestPyPI
@@ -33,6 +33,7 @@ jobs:
   smoke-install:
     runs-on: ubuntu-latest
     needs: publish-testpypi
+    permissions: {}
     steps:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://
 
 Or run the GitHub Actions workflow `TestPyPI Dry Run` to publish and smoke-test install end-to-end.
 
+## Default METR Thresholds
+
+The default model thresholds are defined in `src/agent_estimate/metr_thresholds.yaml`:
+
+| Model | p80 threshold |
+| --- | --- |
+| Opus | 90 minutes |
+| GPT-5.3 | 60 minutes |
+| GPT-5 | 50 minutes |
+| GPT-5.2 | 55 minutes |
+| Gemini 3 Pro | 45 minutes |
+| Sonnet | 30 minutes |
+
 ## Agent Config Example
 
 Pass a custom config file with `--config`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 authors = [{ name = "haoranc" }]
 keywords = ["ai", "agents", "estimation", "pert", "planning"]
 classifiers = [
-  "Development Status :: 1 - Planning",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- refresh README with required packaging sections: description, installation, quick start, usage examples, config example, contributing
- add required badges: PyPI version, Python versions, license, CI
- add Python version classifiers (3.10/3.11/3.12) in package metadata
- add a new GitHub Actions workflow `TestPyPI Dry Run` to build, twine-check, publish to TestPyPI, and smoke-test install

## Validation
- `ruff check .`
- `pytest -q`
- `python -m build`
- `python -m twine check dist/*`

## Notes
- Local non-interactive `python -m twine upload --repository testpypi --skip-existing --non-interactive dist/*` is blocked in this environment due to missing API token.
- The new workflow is intended to run the TestPyPI publish/install validation in GitHub Actions where trusted publishing credentials are configured.
