### PR TITLE
Bump project version to 0.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-estimate",
   "description": "Effort estimation for AI coding agents — PERT three-point estimation with METR reliability thresholds and wave planning",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "author": {
     "name": "haoranc"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-estimate"
-version = "0.0.1"
+version = "0.1.0"
 description = "Effort estimation for AI coding agents — PERT + METR + wave planning"
 readme = "README.md"
 license = "MIT"

--- a/src/agent_estimate/version.py
+++ b/src/agent_estimate/version.py
@@ -1,3 +1,3 @@
 """Version constants for agent-estimate."""
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -4,4 +4,4 @@ from agent_estimate import __version__
 
 
 def test_version_string_present() -> None:
-    assert __version__ == "0.0.1"
+    assert __version__ == "0.1.0"


### PR DESCRIPTION
## Summary
- bump package version to `0.1.0` in `pyproject.toml`
- bump runtime version constant to `0.1.0`
- bump plugin manifest version to `0.1.0`
- update version assertion test accordingly

## Validation
- `PYTHONPATH=src python3 -m pytest -q tests/unit/test_version.py tests/unit/test_plugin_structure.py`
- repo scan confirms no remaining `0.0.1` in project-owned version fields