### PR TITLE
feat: co-dispatch warm context for parallel same-agent tasks

### DIFF
--- a/src/agent_estimate/core/models.py
+++ b/src/agent_estimate/core/models.py
@@ -188,6 +188,14 @@ class WaveAssignment:
     agent_name: str
     slot_index: int
     duration_minutes: float
+    co_dispatch_group: tuple[str, ...] = ()
+    """Task IDs co-dispatched to the same agent in the same wave.
+
+    Non-empty only when two or more tasks are assigned to the same agent within
+    a single wave.  The first task in the group receives no warm-context
+    reduction; subsequent tasks have their ``duration_minutes`` reduced by 0.5x
+    to model implicit warm context carried over from the first task.
+    """
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

- Adds co-dispatch detection to `plan_waves`: when 2+ tasks land on the same agent in one wave, the 2nd and subsequent tasks automatically get a 0.5x warm-context duration reduction
- New `co_dispatch_group` field on `WaveAssignment` (non-empty tuple of co-dispatched task IDs) for downstream flagging/reporting
- Wave makespan calculation already correct (max bin load) — recomputed with adjusted durations after co-dispatch reduction

## Test plan

- [x] 2 tasks on same agent: second gets 0.5x reduction; `co_dispatch_group` populated for both
- [x] Wave makespan uses adjusted durations (40 + 15 = 55, not 40 + 30 = 70)
- [x] 3 tasks on same agent: 2nd and 3rd both get 0.5x
- [x] Tasks on different agents: no reduction, empty `co_dispatch_group`
- [x] Single task on agent: no group, full duration
- [x] Mixed waves: co-dispatch in wave 0, solo task in wave 1 — only wave 0 is flagged
- [x] Updated two pre-existing tests (`TestSingleAgent`, `TestUnbalancedLoad`) with correct new expected makespans
- [x] Full suite: 331 tests passing, ruff clean

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)