### PR TITLE
feat: multi-agent session estimation subcommand

### DIFF
--- a/src/agent_estimate/cli/app.py
+++ b/src/agent_estimate/cli/app.py
@@ -7,6 +7,7 @@ import typer
 
 from agent_estimate.cli.commands.calibrate import run as run_calibrate
 from agent_estimate.cli.commands.estimate import run as run_estimate
+from agent_estimate.cli.commands.session import run as run_session
 from agent_estimate.cli.commands.validate import run as run_validate
 from agent_estimate.version import __version__
 
@@ -44,6 +45,7 @@ def _global_options(
 app.command("estimate")(run_estimate)
 app.command("calibrate")(run_calibrate)
 app.command("validate")(run_validate)
+app.command("session")(run_session)
 
 
 def main() -> None:

--- a/src/agent_estimate/cli/commands/session.py
+++ b/src/agent_estimate/cli/commands/session.py
@@ -1,0 +1,139 @@
+"""Session command — multi-agent coordinated workflow estimation."""
+
+from __future__ import annotations
+
+from typing import NoReturn, Optional
+
+import typer
+
+from agent_estimate.core.session import (
+    DEFAULT_COORDINATION_OVERHEAD_MINUTES,
+    SESSION_TYPE_DURATIONS,
+    estimate_session,
+)
+
+
+def run(
+    agents: int = typer.Option(
+        2,
+        "--agents",
+        "-a",
+        help="Number of parallel agents in the session.",
+        min=1,
+    ),
+    rounds: int = typer.Option(
+        1,
+        "--rounds",
+        "-r",
+        help="Number of sequential rounds.",
+        min=1,
+    ),
+    type: str = typer.Option(  # noqa: A002
+        "brainstorm",
+        "--type",
+        "-t",
+        help=(
+            "Session task type. Known types: "
+            + ", ".join(sorted(SESSION_TYPE_DURATIONS))
+            + "."
+        ),
+    ),
+    coordination_overhead: Optional[float] = typer.Option(
+        None,
+        "--coordination-overhead",
+        help=(
+            f"Coordination overhead per round in minutes "
+            f"(default: {DEFAULT_COORDINATION_OVERHEAD_MINUTES:.0f}m)."
+        ),
+    ),
+    per_round_minutes: Optional[float] = typer.Option(
+        None,
+        "--per-round-minutes",
+        help="Override per-agent per-round duration in minutes (skips type lookup).",
+    ),
+    format: str = typer.Option(  # noqa: A002
+        "markdown",
+        "--format",
+        help="Output format: markdown or json.",
+    ),
+) -> None:
+    """Estimate wall-clock and agent-minutes for a multi-agent session."""
+    overhead = (
+        coordination_overhead
+        if coordination_overhead is not None
+        else DEFAULT_COORDINATION_OVERHEAD_MINUTES
+    )
+
+    try:
+        result = estimate_session(
+            agents=agents,
+            rounds=rounds,
+            task_type=type,
+            coordination_overhead_minutes=overhead,
+            per_round_minutes=per_round_minutes,
+        )
+    except ValueError as exc:
+        _error(str(exc), 2)
+
+    if format == "json":
+        import json
+
+        data = {
+            "agents": result.agents,
+            "rounds": result.rounds,
+            "task_type": result.task_type,
+            "per_agent_round_minutes": result.per_agent_round_minutes,
+            "coordination_overhead_minutes": result.coordination_overhead_minutes,
+            "wall_clock_minutes": result.wall_clock_minutes,
+            "agent_minutes": result.agent_minutes,
+            "rounds_breakdown": list(result.rounds_breakdown),
+        }
+        typer.echo(json.dumps(data, indent=2), nl=False)
+    elif format == "markdown":
+        _render_markdown(result)
+    else:
+        _error(f"Unknown format: {format!r}. Use markdown or json.", 2)
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_markdown(result: "SessionEstimate") -> None:  # type: ignore[name-defined]  # noqa: F821
+    from agent_estimate.core.session import SessionEstimate  # noqa: PLC0415
+
+    assert isinstance(result, SessionEstimate)
+
+    wall_h, wall_m = divmod(int(result.wall_clock_minutes), 60)
+    agent_h, agent_m = divmod(int(result.agent_minutes), 60)
+
+    wall_str = f"{wall_h}h {wall_m}m" if wall_h else f"{wall_m}m"
+    agent_str = f"{agent_h}h {agent_m}m" if agent_h else f"{agent_m}m"
+
+    typer.echo("## Session Estimate\n")
+    typer.echo("| Field                    | Value                      |")
+    typer.echo("|--------------------------|----------------------------|")
+    typer.echo(f"| Agents                   | {result.agents:<26} |")
+    typer.echo(f"| Rounds                   | {result.rounds:<26} |")
+    typer.echo(f"| Task type                | {result.task_type:<26} |")
+    typer.echo(
+        f"| Per-agent per-round      | {result.per_agent_round_minutes:.0f}m{'':<23} |"
+    )
+    typer.echo(
+        f"| Coordination overhead    | {result.coordination_overhead_minutes:.0f}m / round{'':<15} |"
+    )
+    typer.echo(f"| **Wall-clock**           | **{wall_str}**{'':<{22 - len(wall_str)}} |")
+    typer.echo(f"| **Agent-minutes**        | **{agent_str}**{'':<{22 - len(agent_str)}} |")
+
+    if len(result.rounds_breakdown) > 1:
+        typer.echo("\n### Round breakdown\n")
+        for i, rd in enumerate(result.rounds_breakdown, 1):
+            h, m = divmod(int(rd + result.coordination_overhead_minutes), 60)
+            rstr = f"{h}h {m}m" if h else f"{m}m"
+            typer.echo(f"- Round {i}: {rstr} wall-clock")
+
+
+def _error(message: str, exit_code: int) -> NoReturn:
+    typer.echo(f"Error: {message}", err=True)
+    raise typer.Exit(code=exit_code)

--- a/src/agent_estimate/core/session.py
+++ b/src/agent_estimate/core/session.py
@@ -1,0 +1,153 @@
+"""Session-level estimation for coordinated multi-agent workflows.
+
+Models wall-clock vs agent-minutes distinction for parallel agent sessions
+with sequential rounds and coordination overhead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Task type duration stubs
+# ---------------------------------------------------------------------------
+
+#: Default per-agent duration (minutes) for each session task type.
+#: These are conservative base estimates for a single round.
+SESSION_TYPE_DURATIONS: dict[str, float] = {
+    "coding": 50.0,
+    "brainstorm": 10.0,
+    "research": 30.0,
+    "config": 20.0,
+    "documentation": 30.0,
+    "review": 15.0,
+}
+
+#: Default coordination overhead (minutes) added per round to account for
+#: agent synchronization, message passing, and turn-taking latency.
+DEFAULT_COORDINATION_OVERHEAD_MINUTES: float = 5.0
+
+SessionTaskType = Literal[
+    "coding", "brainstorm", "research", "config", "documentation", "review"
+]
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SessionEstimate:
+    """Estimation result for a multi-agent session."""
+
+    agents: int
+    """Number of parallel agents in the session."""
+
+    rounds: int
+    """Number of sequential rounds."""
+
+    task_type: str
+    """Task type key used for per-round duration lookup."""
+
+    per_agent_round_minutes: float
+    """Duration one agent spends per round (before parallelism)."""
+
+    coordination_overhead_minutes: float
+    """Coordination overhead added per round (wall-clock)."""
+
+    wall_clock_minutes: float
+    """Total wall-clock time: sum over rounds of (max_round_duration + overhead)."""
+
+    agent_minutes: float
+    """Total agent-minutes: sum of all individual agent durations across all rounds."""
+
+    rounds_breakdown: tuple[float, ...]
+    """Wall-clock duration for each round (excludes per-round overhead)."""
+
+
+# ---------------------------------------------------------------------------
+# Estimation logic
+# ---------------------------------------------------------------------------
+
+
+def estimate_session(
+    agents: int,
+    rounds: int,
+    task_type: str = "brainstorm",
+    coordination_overhead_minutes: float = DEFAULT_COORDINATION_OVERHEAD_MINUTES,
+    per_round_minutes: float | None = None,
+) -> SessionEstimate:
+    """Estimate wall-clock and agent-minutes for a multi-agent session.
+
+    Wall-clock is computed as::
+
+        wall_clock = sum(max(round_durations_per_agent) + coordination_overhead)
+                   = rounds * (per_agent_round_minutes + coordination_overhead)
+
+    Because all agents run in parallel for the same duration per round,
+    ``max(round_durations)`` simplifies to ``per_agent_round_minutes``.
+
+    Agent-minutes reflects total compute consumed::
+
+        agent_minutes = rounds * agents * per_agent_round_minutes
+
+    Args:
+        agents: Number of parallel agents.
+        rounds: Number of sequential rounds.
+        task_type: Session task type key (brainstorm, research, coding, etc.).
+            Used to look up the per-agent per-round duration baseline.
+        coordination_overhead_minutes: Overhead added per round for
+            synchronization and turn-taking (wall-clock only).
+        per_round_minutes: Override per-agent per-round duration. When
+            provided, ``task_type`` lookup is skipped.
+
+    Returns:
+        A :class:`SessionEstimate` with wall-clock and agent-minutes.
+
+    Raises:
+        ValueError: If agents < 1, rounds < 1, or task_type is unknown
+            and ``per_round_minutes`` is not provided.
+        ValueError: If coordination_overhead_minutes < 0.
+    """
+    if agents < 1:
+        raise ValueError(f"agents must be >= 1, got {agents}")
+    if rounds < 1:
+        raise ValueError(f"rounds must be >= 1, got {rounds}")
+    if coordination_overhead_minutes < 0:
+        raise ValueError(
+            f"coordination_overhead_minutes must be >= 0, got {coordination_overhead_minutes}"
+        )
+
+    if per_round_minutes is not None:
+        if per_round_minutes < 0:
+            raise ValueError(
+                f"per_round_minutes must be >= 0, got {per_round_minutes}"
+            )
+        round_duration = per_round_minutes
+    else:
+        task_type_lower = task_type.lower()
+        if task_type_lower not in SESSION_TYPE_DURATIONS:
+            known = ", ".join(sorted(SESSION_TYPE_DURATIONS))
+            raise ValueError(
+                f"Unknown task type: {task_type!r}. Known types: {known}"
+            )
+        round_duration = SESSION_TYPE_DURATIONS[task_type_lower]
+
+    # All agents run the same task in parallel per round, so wall-clock per
+    # round is round_duration (the max is trivially that value) plus overhead.
+    rounds_breakdown = tuple(round_duration for _ in range(rounds))
+    wall_clock = sum(rd + coordination_overhead_minutes for rd in rounds_breakdown)
+    agent_minutes = rounds * agents * round_duration
+
+    return SessionEstimate(
+        agents=agents,
+        rounds=rounds,
+        task_type=task_type.lower() if per_round_minutes is None else task_type,
+        per_agent_round_minutes=round_duration,
+        coordination_overhead_minutes=coordination_overhead_minutes,
+        wall_clock_minutes=wall_clock,
+        agent_minutes=agent_minutes,
+        rounds_breakdown=rounds_breakdown,
+    )

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,273 @@
+"""Tests for multi-agent session estimation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from agent_estimate.cli.app import app
+from agent_estimate.core.session import (
+    DEFAULT_COORDINATION_OVERHEAD_MINUTES,
+    SESSION_TYPE_DURATIONS,
+    SessionEstimate,
+    estimate_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# Core logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateSessionFormula:
+    """Verify wall-clock and agent-minutes formulae."""
+
+    def test_brainstorm_3agents_2rounds(self) -> None:
+        """3-agent 2-round brainstorm: ~15m wall-clock, 60m agent-minutes."""
+        result = estimate_session(agents=3, rounds=2, task_type="brainstorm")
+        # per_round = 10m (brainstorm default)
+        # wall_clock = 2 * (10 + 5) = 30m
+        # agent_minutes = 2 * 3 * 10 = 60m
+        assert result.per_agent_round_minutes == 10.0
+        assert result.wall_clock_minutes == pytest.approx(30.0)
+        assert result.agent_minutes == pytest.approx(60.0)
+
+    def test_2agent_review_loop(self) -> None:
+        """2-agent review session, 3 rounds."""
+        result = estimate_session(agents=2, rounds=3, task_type="review")
+        # per_round = 15m, overhead = 5m
+        # wall_clock = 3 * (15 + 5) = 60m
+        # agent_minutes = 3 * 2 * 15 = 90m
+        assert result.wall_clock_minutes == pytest.approx(60.0)
+        assert result.agent_minutes == pytest.approx(90.0)
+
+    def test_n_agent_blitz(self) -> None:
+        """5-agent coding blitz, 1 round."""
+        result = estimate_session(agents=5, rounds=1, task_type="coding")
+        # per_round = 50m, overhead = 5m
+        # wall_clock = 1 * (50 + 5) = 55m
+        # agent_minutes = 1 * 5 * 50 = 250m
+        assert result.wall_clock_minutes == pytest.approx(55.0)
+        assert result.agent_minutes == pytest.approx(250.0)
+
+    def test_single_agent_single_round(self) -> None:
+        """Degenerate 1-agent 1-round case."""
+        result = estimate_session(agents=1, rounds=1, task_type="research")
+        # wall_clock = 30 + 5 = 35m
+        # agent_minutes = 30m
+        assert result.wall_clock_minutes == pytest.approx(35.0)
+        assert result.agent_minutes == pytest.approx(30.0)
+
+    def test_wall_clock_less_than_agent_minutes_for_multi_agent(self) -> None:
+        """Wall-clock should be < agent-minutes when agents > 1."""
+        result = estimate_session(agents=4, rounds=2, task_type="brainstorm")
+        assert result.wall_clock_minutes < result.agent_minutes
+
+    def test_coordination_overhead_zero(self) -> None:
+        """Zero overhead: wall-clock = rounds * per_round."""
+        result = estimate_session(
+            agents=3, rounds=2, task_type="brainstorm", coordination_overhead_minutes=0
+        )
+        assert result.wall_clock_minutes == pytest.approx(
+            2 * SESSION_TYPE_DURATIONS["brainstorm"]
+        )
+
+    def test_custom_coordination_overhead(self) -> None:
+        """Custom overhead applies per round."""
+        result = estimate_session(
+            agents=2,
+            rounds=3,
+            task_type="brainstorm",
+            coordination_overhead_minutes=10.0,
+        )
+        # wall_clock = 3 * (10 + 10) = 60m
+        assert result.wall_clock_minutes == pytest.approx(60.0)
+
+    def test_per_round_minutes_override(self) -> None:
+        """Explicit per_round_minutes skips task type lookup."""
+        result = estimate_session(agents=2, rounds=2, per_round_minutes=25.0)
+        assert result.per_agent_round_minutes == pytest.approx(25.0)
+        assert result.wall_clock_minutes == pytest.approx(2 * (25.0 + 5.0))
+        assert result.agent_minutes == pytest.approx(2 * 2 * 25.0)
+
+    def test_rounds_breakdown_length(self) -> None:
+        """rounds_breakdown should have one entry per round."""
+        result = estimate_session(agents=2, rounds=4, task_type="documentation")
+        assert len(result.rounds_breakdown) == 4
+
+    def test_rounds_breakdown_values(self) -> None:
+        """Each breakdown entry should equal per_agent_round_minutes."""
+        result = estimate_session(agents=2, rounds=3, task_type="config")
+        per_round = SESSION_TYPE_DURATIONS["config"]
+        assert all(rd == pytest.approx(per_round) for rd in result.rounds_breakdown)
+
+
+class TestEstimateSessionReturnType:
+    """Verify the return type fields are correct."""
+
+    def test_returns_session_estimate(self) -> None:
+        result = estimate_session(agents=2, rounds=1, task_type="brainstorm")
+        assert isinstance(result, SessionEstimate)
+
+    def test_fields_match_inputs(self) -> None:
+        result = estimate_session(agents=3, rounds=2, task_type="research")
+        assert result.agents == 3
+        assert result.rounds == 2
+        assert result.task_type == "research"
+        assert result.coordination_overhead_minutes == DEFAULT_COORDINATION_OVERHEAD_MINUTES
+
+
+class TestEstimateSessionValidation:
+    """Verify input validation raises appropriate errors."""
+
+    def test_zero_agents_raises(self) -> None:
+        with pytest.raises(ValueError, match="agents must be >= 1"):
+            estimate_session(agents=0, rounds=1)
+
+    def test_negative_agents_raises(self) -> None:
+        with pytest.raises(ValueError, match="agents must be >= 1"):
+            estimate_session(agents=-1, rounds=1)
+
+    def test_zero_rounds_raises(self) -> None:
+        with pytest.raises(ValueError, match="rounds must be >= 1"):
+            estimate_session(agents=1, rounds=0)
+
+    def test_unknown_task_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown task type"):
+            estimate_session(agents=1, rounds=1, task_type="unknown_type_xyz")
+
+    def test_negative_overhead_raises(self) -> None:
+        with pytest.raises(ValueError, match="coordination_overhead_minutes must be >= 0"):
+            estimate_session(agents=1, rounds=1, coordination_overhead_minutes=-1.0)
+
+    def test_negative_per_round_minutes_raises(self) -> None:
+        with pytest.raises(ValueError, match="per_round_minutes must be >= 0"):
+            estimate_session(agents=1, rounds=1, per_round_minutes=-5.0)
+
+    def test_unknown_type_ok_when_per_round_provided(self) -> None:
+        """Unknown task type is fine when per_round_minutes is provided."""
+        result = estimate_session(
+            agents=1, rounds=1, task_type="anything", per_round_minutes=20.0
+        )
+        assert result.per_agent_round_minutes == pytest.approx(20.0)
+
+
+class TestAllKnownTaskTypes:
+    """All known task types should resolve without error."""
+
+    @pytest.mark.parametrize("task_type", list(SESSION_TYPE_DURATIONS.keys()))
+    def test_known_type(self, task_type: str) -> None:
+        result = estimate_session(agents=2, rounds=2, task_type=task_type)
+        assert result.per_agent_round_minutes == SESSION_TYPE_DURATIONS[task_type]
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+runner = CliRunner()
+
+
+class TestSessionCLIMarkdown:
+    """CLI session subcommand — markdown output."""
+
+    def test_default_brainstorm(self) -> None:
+        result = runner.invoke(app, ["session", "--agents", "3", "--rounds", "2"])
+        assert result.exit_code == 0
+        assert "Session Estimate" in result.output
+        assert "Wall-clock" in result.output
+        assert "Agent-minutes" in result.output
+
+    def test_explicit_type(self) -> None:
+        result = runner.invoke(
+            app, ["session", "--agents", "2", "--rounds", "1", "--type", "research"]
+        )
+        assert result.exit_code == 0
+        assert "research" in result.output
+
+    def test_round_breakdown_multi_round(self) -> None:
+        result = runner.invoke(
+            app, ["session", "--agents", "2", "--rounds", "3", "--type", "brainstorm"]
+        )
+        assert result.exit_code == 0
+        assert "Round breakdown" in result.output
+        assert "Round 1" in result.output
+        assert "Round 3" in result.output
+
+    def test_single_round_no_breakdown(self) -> None:
+        result = runner.invoke(
+            app, ["session", "--agents", "2", "--rounds", "1", "--type", "brainstorm"]
+        )
+        assert result.exit_code == 0
+        assert "Round breakdown" not in result.output
+
+    def test_coordination_overhead_flag(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "session",
+                "--agents", "2",
+                "--rounds", "1",
+                "--type", "brainstorm",
+                "--coordination-overhead", "0",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_per_round_minutes_flag(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "session",
+                "--agents", "2",
+                "--rounds", "2",
+                "--per-round-minutes", "15",
+            ],
+        )
+        assert result.exit_code == 0
+
+
+class TestSessionCLIJson:
+    """CLI session subcommand — JSON output."""
+
+    def test_json_output_structure(self) -> None:
+        result = runner.invoke(
+            app,
+            ["session", "--agents", "3", "--rounds", "2", "--type", "brainstorm", "--format", "json"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["agents"] == 3
+        assert data["rounds"] == 2
+        assert data["task_type"] == "brainstorm"
+        assert "wall_clock_minutes" in data
+        assert "agent_minutes" in data
+        assert "rounds_breakdown" in data
+        assert len(data["rounds_breakdown"]) == 2
+
+    def test_json_values_match_formula(self) -> None:
+        result = runner.invoke(
+            app,
+            ["session", "--agents", "3", "--rounds", "2", "--type", "brainstorm", "--format", "json"],
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # wall_clock = 2 * (10 + 5) = 30m
+        assert data["wall_clock_minutes"] == pytest.approx(30.0)
+        # agent_minutes = 2 * 3 * 10 = 60m
+        assert data["agent_minutes"] == pytest.approx(60.0)
+
+
+class TestSessionCLIErrors:
+    """CLI session subcommand — error handling."""
+
+    def test_unknown_format(self) -> None:
+        result = runner.invoke(app, ["session", "--format", "xml"])
+        assert result.exit_code != 0
+
+    def test_unknown_task_type(self) -> None:
+        result = runner.invoke(app, ["session", "--type", "unknown_xyz"])
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Adds `agent-estimate session` subcommand for estimating coordinated multi-agent workflow sessions
- Implements the wall-clock vs agent-minutes formula: `wall_clock = sum(max(round_durations) + coordination_overhead)`, `agent_minutes = sum(all individual durations)`
- Includes stub task type durations (brainstorm 10m, research 30m, coding 50m, etc.) for session-level estimation independent of the main pipeline

## Key files

- `src/agent_estimate/core/session.py` — `estimate_session()` core logic and `SessionEstimate` dataclass
- `src/agent_estimate/cli/commands/session.py` — `session` subcommand with `--agents`, `--rounds`, `--type`, `--coordination-overhead`, `--per-round-minutes`, `--format` flags
- `src/agent_estimate/cli/app.py` — registered new `session` subcommand
- `tests/unit/test_session.py` — 35 tests covering: formula correctness, CLI output (markdown + JSON), input validation, all known task types

## Test plan

- [x] `python3 -m pytest tests/ -x -q` — 405 tests passing (was 370 before, +35 session tests)
- [x] `ruff check .` — clean
- [x] Manual spot-check: `agent-estimate session --agents 3 --rounds 2 --type brainstorm` → 30m wall-clock, 60m agent-minutes
- [x] Common session patterns covered: 2-agent review loop, 3-agent brainstorm, N-agent blitz, 1-round degenerate

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)