### PR TITLE
feat: amortize review overhead per agent per wave (#49)

### DIFF
--- a/src/agent_estimate/cli/commands/_pipeline.py
+++ b/src/agent_estimate/cli/commands/_pipeline.py
@@ -134,12 +134,15 @@ def run_estimate_pipeline(
         names.append(name)
         estimates.append(est)
 
-    # Build TaskNodes for wave planning (friction applied here)
+    # Build TaskNodes for wave planning (friction applied to work only).
+    # review_minutes is kept separate so the wave planner can amortize it
+    # across same-agent tasks in each wave (batch review amortization).
     friction = config.settings.friction_multiplier
     task_nodes = [
         TaskNode(
             task_id=str(i),
-            duration_minutes=est.total_expected_minutes * friction,
+            duration_minutes=est.pert.expected * friction,
+            review_minutes=est.review_minutes,
         )
         for i, est in enumerate(estimates)
     ]
@@ -234,6 +237,7 @@ def _build_report(
                 )
                 for agent_name in {a.agent_name for a in wave.assignments}
             },
+            agent_review_minutes=dict(wave.agent_review_minutes),
         )
         for wave in wave_plan.waves
     )

--- a/src/agent_estimate/core/models.py
+++ b/src/agent_estimate/core/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import enum
 from collections.abc import Mapping, Sequence
+import dataclasses
 from dataclasses import dataclass
 from typing import Annotated, Protocol, runtime_checkable
 
@@ -192,12 +193,19 @@ class TaskEstimate:
 
 @dataclass(frozen=True)
 class TaskNode:
-    """Input: one task to be scheduled."""
+    """Input: one task to be scheduled.
+
+    ``duration_minutes`` is the work-only duration (no review).
+    ``review_minutes`` is the per-task review overhead; the wave planner
+    amortizes this across same-agent tasks in each wave so only a single
+    review cycle is charged per agent per wave.
+    """
 
     task_id: str
     duration_minutes: float
     dependencies: tuple[str, ...] = ()
     required_capabilities: tuple[str, ...] = ()
+    review_minutes: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -220,12 +228,18 @@ class WaveAssignment:
 
 @dataclass(frozen=True)
 class Wave:
-    """A single scheduling wave."""
+    """A single scheduling wave.
+
+    ``agent_review_minutes`` maps each agent to the single amortized review
+    cycle charged for that agent in this wave (0.0 when review_mode is NONE
+    or the agent has no tasks in the wave).
+    """
 
     wave_number: int
     start_minutes: float
     end_minutes: float
     assignments: tuple[WaveAssignment, ...]
+    agent_review_minutes: Mapping[str, float] = dataclasses.field(default_factory=dict)  # type: ignore[assignment]
 
 
 @dataclass(frozen=True)

--- a/src/agent_estimate/render/json_report.py
+++ b/src/agent_estimate/render/json_report.py
@@ -85,4 +85,5 @@ def _wave_payload(wave: ReportWave) -> dict[str, Any]:
         "tasks": sorted(wave.tasks),
         "duration_minutes": wave.duration_minutes,
         "agent_assignments": assignments,
+        "agent_review_minutes": dict(sorted(wave.agent_review_minutes.items())),
     }

--- a/src/agent_estimate/render/report_models.py
+++ b/src/agent_estimate/render/report_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -62,12 +63,18 @@ class ReportTask:
 
 @dataclass(frozen=True)
 class ReportWave:
-    """One scheduling wave in the report."""
+    """One scheduling wave in the report.
+
+    ``agent_review_minutes`` maps each agent name to the single amortized
+    review cycle charged for that agent in this wave.  Empty when all tasks
+    have review_minutes=0 (i.e. ReviewMode.NONE).
+    """
 
     number: int
     tasks: tuple[str, ...]
     duration_minutes: float
     agent_assignments: Mapping[str, tuple[str, ...]]
+    agent_review_minutes: Mapping[str, float] = dataclasses.field(default_factory=dict)  # type: ignore[assignment]
 
 
 @dataclass(frozen=True)

--- a/tests/fixtures/json_report_golden.json
+++ b/tests/fixtures/json_report_golden.json
@@ -88,6 +88,7 @@
           "Implement auth"
         ]
       },
+      "agent_review_minutes": {},
       "duration_minutes": 85.0,
       "number": 1,
       "tasks": [

--- a/tests/integration/test_regression.py
+++ b/tests/integration/test_regression.py
@@ -62,7 +62,7 @@ class TestSingleTaskSimpleLinear:
             "Per-Task Estimates",
             "Wave Plan",
             "Timeline Summary",
-            "Review Overhead (Additive)",
+            "Review Overhead",
             "Agent Load Summary",
             "Critical Path",
             "METR Warnings",
@@ -87,7 +87,7 @@ class TestSingleTaskSimpleLinear:
 
     def test_review_overhead_zero_for_none_mode(self) -> None:
         output = self._run()
-        section = _extract_section(output, "Review Overhead (Additive)")
+        section = _extract_section(output, "Review Overhead")
         # The total review overhead should be 0m for review_mode=none
         assert "0m" in section
 
@@ -152,8 +152,8 @@ class TestMultiTaskParallelFanout:
     def test_review_overhead_positive_for_default_mode(self) -> None:
         output = self._run()
         # Default review mode is standard (15 m), so overhead should be > 0
-        section = _extract_section(output, "Review Overhead (Additive)")
-        total_line = [ln for ln in section.splitlines() if "**Total**" in ln]
+        section = _extract_section(output, "Review Overhead")
+        total_line = [ln for ln in section.splitlines() if "**Total" in ln]
         assert len(total_line) == 1
         match = re.search(r"(\d+(?:\.\d+)?)m", total_line[0])
         assert match

--- a/tests/unit/test_markdown_report.py
+++ b/tests/unit/test_markdown_report.py
@@ -180,8 +180,8 @@ def test_render_markdown_report_contains_required_sections() -> None:
     assert "## Agent Load Summary" in rendered
     assert "## Critical Path" in rendered
     assert "## METR Warnings" in rendered
-    assert "| Review overhead (additive) | 25m |" in rendered
-    assert "| **Total** | **25m** |" in rendered
+    assert "| Review overhead (per-task, pre-amortization) | 25m |" in rendered
+    assert "| **Total (naive)** | **25m** |" in rendered
     assert "**Implement auth**" in rendered
     assert "Claude: Add tests; Codex: Implement auth" in rendered
     assert "Compression ratio | 2.78x" in rendered


### PR DESCRIPTION
## Summary

- Separates work duration from review overhead in `TaskNode` with a new `review_minutes` field
- Wave planner now charges a **single review cycle per agent per wave** instead of one per task, matching observed actuals (W5: 104m estimated → 42m actual for 3-task Claude batch)
- Per-agent amortized review exposed in `Wave.agent_review_minutes`, `ReportWave.agent_review_minutes`, JSON output, and markdown wave table
- Sequential baseline updated to include per-task review for accurate parallel efficiency comparison

## Changes

- `core/models.py` — `TaskNode.review_minutes` field; `Wave.agent_review_minutes` mapping
- `core/wave_planner.py` — batch review amortization after LPT/co-dispatch; leading-slot review charge
- `cli/commands/_pipeline.py` — pass work-only duration + review separately to `TaskNode`
- `render/json_report.py` — include `agent_review_minutes` in wave payload
- `render/markdown_report.py` — show per-agent review note in wave table; update section heading
- `render/report_models.py` — `ReportWave.agent_review_minutes` field
- 8 new unit tests in `test_wave_planner.py`; golden fixture + integration test updates

## Test plan

- [x] `ruff check .` — clean
- [x] `python3 -m pytest tests/ -x -q` — 378 passed (370 original + 8 new)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)