### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-estimate",
   "description": "Effort estimation for AI coding agents — PERT three-point estimation with METR reliability thresholds and wave planning",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "haoranc"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-21
+
 ### Changed
 - Review overhead model is now additive (0m / 15m / 25m) instead of percentage-based. ReviewMode values: `none`, `standard`, `complex`. Legacy `self` and `2x-lgtm` still accepted for backwards compatibility. (#46)
 
@@ -17,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Batch wave estimation: amortizes review overhead across same-agent tasks per wave — single review cycle per agent instead of per task. `TaskNode.review_minutes` separates review from work duration. (#49)
 - Non-coding task type estimation: `--type` flag for brainstorm, research, config, and documentation tasks with category-specific models. Auto-detection heuristic from description keywords. (#55)
 - Multi-agent session estimation: `agent-estimate session` subcommand for coordinated workflows. Wall-clock vs agent-minutes distinction with `--agents`, `--rounds`, `--type` flags. (#56)
+
+### Fixed
+- 11 post-LGTM nits from ae-task-models blitz: fractional minute rounding, deterministic wave tie-breaking, tightened keyword patterns, parallel efficiency calculation, and JSON report completeness. (#63)
 
 ## [0.1.0] - 2026-02-18
 
@@ -34,5 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modifier flags: `--warm-context`, `--spec-clarity`, `--issues`
 - PyPI package: `pip install agent-estimate`
 
+[0.2.0]: https://github.com/haoranc/agent-estimate/releases/tag/v0.2.0
 [0.1.0]: https://github.com/haoranc/agent-estimate/releases/tag/v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 - three-point PERT estimates
 - METR-style model reliability thresholds
 - dependency-aware wave planning
-- explicit review overhead modes (`none`, `self`, `2x-lgtm`)
+- explicit review overhead modes (`none`, `standard`, `complex`)
+- non-coding task type estimation (brainstorm, research, config, docs)
+- multi-agent session estimation
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-estimate"
-version = "0.1.0"
+version = "0.2.0"
 description = "Effort estimation for AI coding agents — PERT + METR + wave planning"
 readme = "README.md"
 license = "MIT"

--- a/src/agent_estimate/version.py
+++ b/src/agent_estimate/version.py
@@ -1,3 +1,3 @@
 """Version constants for agent-estimate."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -4,4 +4,4 @@ from agent_estimate import __version__
 
 
 def test_version_string_present() -> None:
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.2.0"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.2.0 across all 4 version sources (`version.py`, `pyproject.toml`, `plugin.json`, `test_version.py`)
- Move CHANGELOG Unreleased entries to `[0.2.0] - 2026-02-21`, add Fixed section for #63 nits
- Update README feature list: review modes (`standard`/`complex`), non-coding task types, session estimation

## Test plan
- [x] 480 tests passing
- [x] `test_version_string_present` updated to expect `0.2.0`
- [x] Grep confirms no stale `0.1.0` references (only historical CHANGELOG entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)