### PR TITLE
chore: update copyright to Kiloloop LLC

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Haoran Cheng
+   Copyright 2026 Kiloloop LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 agent-estimate
-Copyright 2026 Haoran Cheng
+Copyright 2026 Kiloloop LLC


### PR DESCRIPTION
Summary:
- update ownership notice in LICENSE to Kiloloop LLC
- update NOTICE to match the new copyright holder
- keep Apache 2.0 license terms and package metadata unchanged

Validation:
- ruff check .
- pytest -q